### PR TITLE
Add value to enum validation error message

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -683,7 +683,8 @@ sub _validate_type_enum {
   }
 
   local $" = ', ';
-  return E $path, sprintf 'Not in enum list: %s.', join ', ',
+  my $encoded_data = Mojo::JSON::encode_json($data);
+  return E $path, sprintf 'Not in enum list (%s): %s.', $encoded_data, join ', ',
     map { (!defined or ref) ? Mojo::JSON::encode_json($_) : $_ } @$enum;
 }
 

--- a/t/issue-22-duplicate-error-messages.t
+++ b/t/issue-22-duplicate-error-messages.t
@@ -2,7 +2,7 @@ use lib '.';
 use t::Helper;
 
 # https://github.com/jhthorsen/json-validator/issues/22
-validate_ok {foo => 'x'}, 'data://main/test.schema', E('/foo', 'Not in enum list: bar, baz.');
+validate_ok {foo => 'x'}, 'data://main/test.schema', E('/foo', 'Not in enum list ("x"): bar, baz.');
 validate_ok {foo => 123}, 'data://main/test.schema', E('/foo', 'Expected string - got number.');
 
 done_testing;

--- a/t/jv-enum.t
+++ b/t/jv-enum.t
@@ -9,11 +9,11 @@ validate_ok {name => "Dave",  chromosomes => [qw(X Y)]}, $male;
 validate_ok {name => "Arnie", chromosomes => [qw(Y X)]}, $male;
 
 validate_ok {name => "Kate", chromosomes => [qw(X X)]}, $male,
-  E('/chromosomes', 'Not in enum list: ["X","Y"], ["Y","X"].');
-validate_ok {name => "Eddie", chromosomes => [qw(X YY )]}, $male,
-  E('/chromosomes', 'Not in enum list: ["X","Y"], ["Y","X"].');
+  E('/chromosomes', 'Not in enum list (["X","X"]): ["X","Y"], ["Y","X"].');
+validate_ok {name => "Eddie", chromosomes => [qw(X YY)]}, $male,
+  E('/chromosomes', 'Not in enum list (["X","YY"]): ["X","Y"], ["Y","X"].');
 validate_ok {name => "Steve", chromosomes => 'XY'}, $male,
-  E('/chromosomes', 'Not in enum list: ["X","Y"], ["Y","X"].');
+  E('/chromosomes', 'Not in enum list ("XY"): ["X","Y"], ["Y","X"].');
 
 # https://github.com/jhthorsen/json-validator/issues/69
 validate_ok(
@@ -30,7 +30,7 @@ validate_ok(
       },
     },
   },
-  E('/some_prop/0', 'Not in enum list: x, y.')
+  E('/some_prop/0', 'Not in enum list ("foo"): x, y.')
 );
 
 for my $v (undef, false, true) {
@@ -52,7 +52,7 @@ validate_ok(
     properties => {name => {type => ['string'], enum => [qw(n yes true false)]}},
   },
   E('/name', '/anyOf Expected string, got null.'),
-  E('/name', 'Not in enum list: n, yes, true, false.'),
+  E('/name', 'Not in enum list (null): n, yes, true, false.'),
 );
 
 done_testing;


### PR DESCRIPTION
### Summary
Improve the error message for enum validation failures

### Motivation
The error message did not contain the value that had failed validation, making it more difficult than needed to either find the item with the incorrect data or add it to the enum if it was actually valid.