### PR TITLE
Add JSON::Validator::Error->details()

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -612,7 +612,7 @@ sub _validate {
   if (my $rules = $schema->{not}) {
     push @errors, $self->_validate($to_json ? $$to_json : $_[1], $path, $rules);
     $self->_report_errors($path, 'not', \@errors) if REPORT;
-    return @errors ? () : (E $path, 'Should not match.');
+    return @errors ? () : (E $path, [not => 'not']);
   }
 
   if (my $rules = $schema->{allOf}) {
@@ -651,7 +651,7 @@ sub _validate_all_of {
   }
 
   $self->_report_errors($path, 'allOf', \@errors) if REPORT;
-  return E $path, "/allOf Expected @{[join '/', _uniq(@expected)]} - got $type."
+  return E $path, [allOf => type => join('/', _uniq(@expected)), $type]
     if !@errors and @expected;
   return _add_path_to_error_messages(allOf => @errors) if @errors;
   return;
@@ -679,7 +679,7 @@ sub _validate_any_of {
 
   $self->_report_errors($path, 'anyOf', \@errors) if REPORT;
   my $expected = join '/', _uniq(@expected);
-  return E $path, "/anyOf Expected $expected - got $type." unless @errors;
+  return E $path, [anyOf => type => $expected, $type] unless @errors;
   return _add_path_to_error_messages(anyOf => @errors);
 }
 
@@ -712,8 +712,8 @@ sub _validate_one_of {
 
   return if @errors + @expected + 1 == @$rules;
   my $expected = join '/', _uniq(@expected);
-  return E $path, "All of the oneOf rules match." unless @errors + @expected;
-  return E $path, "/oneOf Expected $expected - got $type." unless @errors;
+  return E $path, [oneOf => 'all_rules_match'] unless @errors + @expected;
+  return E $path, [oneOf => type => $expected => $type] unless @errors;
   return _add_path_to_error_messages(oneOf => @errors);
 }
 
@@ -726,9 +726,9 @@ sub _validate_type_enum {
     return if $m eq S $i;
   }
 
-  local $" = ', ';
-  return E $path, sprintf 'Not in enum list: %s.', join ', ',
+  $enum = join ', ',
     map { (!defined or ref) ? Mojo::JSON::encode_json($_) : $_ } @$enum;
+  return E $path, [enum => enum => $enum];
 }
 
 sub _validate_type_const {
@@ -737,8 +737,7 @@ sub _validate_type_const {
   my $m     = S $data;
 
   return if $m eq S $const;
-  return E $path, sprintf 'Does not match const: %s.',
-    Mojo::JSON::encode_json($const);
+  return E $path, [const => const => Mojo::JSON::encode_json($const)];
 }
 
 sub _validate_format {
@@ -747,7 +746,7 @@ sub _validate_format {
   return do { warn "Format rule for '$schema->{format}' is missing"; return }
     unless $code;
   return unless my $err = $code->($value);
-  return E $path, $err;
+  return E $path, [format => $schema->{format}, $err];
 }
 
 sub _validate_type_any { }
@@ -757,21 +756,21 @@ sub _validate_type_array {
   my @errors;
 
   if (ref $data ne 'ARRAY') {
-    return E $path, _expected(array => $data);
+    return E $path, [array => type => _guess_data_type($data)];
   }
   if (defined $schema->{minItems} and $schema->{minItems} > @$data) {
-    push @errors, E $path, sprintf 'Not enough items: %s/%s.', int @$data,
-      $schema->{minItems};
+    push @errors, E $path,
+      [array => minItems => int(@$data), $schema->{minItems}];
   }
   if (defined $schema->{maxItems} and $schema->{maxItems} < @$data) {
-    push @errors, E $path, sprintf 'Too many items: %s/%s.', int @$data,
-      $schema->{maxItems};
+    push @errors, E $path,
+      [array => maxItems => int(@$data), $schema->{maxItems}];
   }
   if ($schema->{uniqueItems}) {
     my %uniq;
     for (@$data) {
       next if !$uniq{S($_)}++;
-      push @errors, E $path, 'Unique items required.';
+      push @errors, E $path, [array => 'uniqueItems'];
       last;
     }
   }
@@ -798,8 +797,8 @@ sub _validate_type_array {
       }
     }
     elsif (!$additional_items) {
-      push @errors, E $path, sprintf "Invalid number of items: %s/%s.",
-        int(@$data), int(@rules);
+      push @errors, E $path,
+        [array => additionalItems => int(@$data), int(@rules)];
     }
   }
   elsif (UNIVERSAL::isa($schema->{items}, 'HASH')) {
@@ -833,7 +832,7 @@ sub _validate_type_boolean {
     return;
   }
 
-  return E $path, _expected(boolean => $value);
+  return E $path, [boolean => type => _guess_data_type($value)];
 }
 
 sub _validate_type_integer {
@@ -842,14 +841,14 @@ sub _validate_type_integer {
 
   return @errors if @errors;
   return if $value =~ /^-?\d+$/;
-  return E $path, "Expected integer - got number.";
+  return E $path, [integer => type => _guess_data_type($value)];
 }
 
 sub _validate_type_null {
   my ($self, $value, $path, $schema) = @_;
 
-  return E $path, 'Not null.' if defined $value;
-  return;
+  return unless defined $value;
+  return E $path, ['null', 'null'];
 }
 
 sub _validate_type_number {
@@ -859,10 +858,10 @@ sub _validate_type_number {
   $expected ||= 'number';
 
   if (!defined $value or ref $value) {
-    return E $path, _expected($expected => $value);
+    return E $path, [$expected => type => _guess_data_type($value)];
   }
   unless (_is_number($value)) {
-    return E $path, "Expected $expected - got string."
+    return E $path, [$expected => type => _guess_data_type($value)]
       if !$self->{coerce}{numbers}
       or $value !~ /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/;
     $_[1] = 0 + $value;    # coerce input value
@@ -874,16 +873,16 @@ sub _validate_type_number {
   if (my $e
     = _cmp($schema->{minimum}, $value, $schema->{exclusiveMinimum}, '<'))
   {
-    push @errors, E $path, "$value $e minimum($schema->{minimum})";
+    push @errors, E $path, [$expected => minimum => $value, $schema->{minimum}];
   }
   if (my $e
     = _cmp($value, $schema->{maximum}, $schema->{exclusiveMaximum}, '>'))
   {
-    push @errors, E $path, "$value $e maximum($schema->{maximum})";
+    push @errors, E $path, [$expected => maximum => $value, $schema->{maximum}];
   }
   if (my $d = $schema->{multipleOf}) {
     if (($value / $d) =~ /\.[^0]+$/) {
-      push @errors, E $path, "Not multiple of $d.";
+      push @errors, E $path, [$expected => multipleOf => $d];
     }
   }
 
@@ -896,17 +895,17 @@ sub _validate_type_object {
   my ($additional, @errors, %rules);
 
   if (ref $data ne 'HASH') {
-    return E $path, _expected(object => $data);
+    return E $path, [object => type => _guess_data_type($data)];
   }
 
   my @dkeys = sort keys %$data;
   if (defined $schema->{maxProperties} and $schema->{maxProperties} < @dkeys) {
-    push @errors, E $path, sprintf 'Too many properties: %s/%s.', int @dkeys,
-      $schema->{maxProperties};
+    push @errors, E $path,
+      [object => maxProperties => int(@dkeys), $schema->{maxProperties}];
   }
   if (defined $schema->{minProperties} and $schema->{minProperties} > @dkeys) {
-    push @errors, E $path, sprintf 'Not enough properties: %s/%s.', int @dkeys,
-      $schema->{minProperties};
+    push @errors, E $path,
+      [object => minProperties => int(@dkeys), $schema->{minProperties}];
   }
   if (my $n_schema = $schema->{propertyNames}) {
     for my $name (keys %$data) {
@@ -943,12 +942,12 @@ sub _validate_type_object {
   }
   elsif (my @k = grep { !$rules{$_} } @dkeys) {
     local $" = ', ';
-    return E $path, "Properties not allowed: @k.";
+    return E $path, [object => additionalProperties => join '/', @k];
   }
 
   for my $k (sort keys %required) {
     next if exists $data->{$k};
-    push @errors, E _path($path, $k), 'Missing property.';
+    push @errors, E _path($path, $k), [object => 'required'];
     delete $rules{$k};
   }
 
@@ -975,13 +974,13 @@ sub _validate_type_string {
   my @errors;
 
   if (!defined $value or ref $value) {
-    return E $path, _expected(string => $value);
+    return E $path, [string => type => _guess_data_type($value)];
   }
   if (  B::svref_2object(\$value)->FLAGS & (B::SVp_IOK | B::SVp_NOK)
     and 0 + $value eq $value
     and $value * 0 == 0)
   {
-    return E $path, "Expected string - got number."
+    return E $path, [string => type => _guess_data_type($value)]
       unless $self->{coerce}{strings};
     $_[1] = "$value";    # coerce input value
   }
@@ -990,21 +989,19 @@ sub _validate_type_string {
   }
   if (defined $schema->{maxLength}) {
     if (length($value) > $schema->{maxLength}) {
-      push @errors, E $path, sprintf "String is too long: %s/%s.",
-        length($value), $schema->{maxLength};
+      push @errors, E $path,
+        [string => maxLength => length($value), $schema->{maxLength}];
     }
   }
   if (defined $schema->{minLength}) {
     if (length($value) < $schema->{minLength}) {
-      push @errors, E $path, sprintf "String is too short: %s/%s.",
-        length($value), $schema->{minLength};
+      push @errors, E $path,
+        [string => minLength => length($value), $schema->{minLength}];
     }
   }
   if (defined $schema->{pattern}) {
     my $p = $schema->{pattern};
-    unless ($value =~ /$p/) {
-      push @errors, E $path, "String does not match '$p'";
-    }
+    push @errors, E $path, [string => pattern => $p] unless $value =~ /$p/;
   }
 
   return @errors;
@@ -1019,7 +1016,7 @@ sub _add_path_to_error_messages {
   for my $e (@errors_with_index) {
     my $index = shift @$e;
     push @errors, map {
-      my $msg = sprintf '/%s/%s %s', $type, $index, $_->{message};
+      my $msg = sprintf '/%s/%s %s', $type, $index, $_->message;
       $msg =~ s!(\d+)\s/!$1/!g;
       E $_->path, $msg;
     } @$e;
@@ -1033,12 +1030,6 @@ sub _cmp {
   return "$_[3]=" if $_[2] and $_[0] >= $_[1];
   return $_[3] if $_[0] > $_[1];
   return "";
-}
-
-sub _expected {
-  my $type = _guess_data_type($_[1], []);
-  return "Expected $_[0] - got different $type." if $_[0] =~ /\b$type\b/;
-  return "Expected $_[0] - got $type.";
 }
 
 # _guess_data_type($data, [{type => ...}, ...])

--- a/lib/JSON/Validator/Error.pm
+++ b/lib/JSON/Validator/Error.pm
@@ -3,16 +3,92 @@ use Mojo::Base -base;
 
 use overload q("") => \&to_string, bool => sub {1}, fallback => 1;
 
+our %MESSAGES = (
+  allOf => {type => '/allOf Expected %3 - got %4.'},
+  anyOf => {type => '/anyOf Expected %3 - got %4.'},
+  array => {
+    additionalItems => 'Invalid number of items: %3/%4.',
+    maxItems        => 'Too many items: %3/%4.',
+    minItems        => 'Not enough items: %3/%4.',
+    uniqueItems     => 'Unique items required.',
+  },
+  const   => {const => 'Does not match const: %3.'},
+  enum    => {enum  => 'Not in enum list: %3.'},
+  integer => {
+    maximum    => '%3 > maximum(%4)',
+    minimum    => '%3 < minimum(%4)',
+    multipleOf => 'Not multiple of %3.',
+  },
+  not    => {not  => 'Should not match.'},
+  null   => {null => 'Not null.'},
+  number => {
+    maximum    => '%3 > maximum(%4)',
+    minimum    => '%3 < minimum(%4)',
+    multipleOf => 'Not multiple of %3.',
+  },
+  object => {
+    additionalProperties => 'Properties not allowed: %3.',
+    maxProperties        => 'Too many properties: %3/%4.',
+    minProperties        => 'Not enough properties: %3/%4.',
+    required             => 'Missing property.',
+  },
+  oneOf => {
+    all_rules_match => 'All of the oneOf rules match.',
+    type            => '/oneOf Expected %3 - got %4.',
+  },
+  string => {
+    pattern   => 'String does not match %3.',
+    maxLength => 'String is too long: %3/%4.',
+    minLength => 'String is too short: %3/%4.',
+  }
+);
+
+has details => sub { [qw(generic generic)] };
+
+has message => sub {
+  my $self    = shift;
+  my $details = $self->details;
+  my $message;
+
+  if (($details->[0] || '') eq 'format') {
+    $message = '%3';
+  }
+  elsif (($details->[1] || '') eq 'type' and @$details == 3) {
+    $message = 'Expected %1 - got %3.';
+  }
+  elsif (my $group = $MESSAGES{$details->[0]}) {
+    $message = $group->{$details->[1] || 'default'};
+  }
+
+  return join ' ', Failed => @$details unless defined $message;
+
+  $message =~ s!\%(\d)\b!{$details->[$1 - 1] // ''}!ge;
+  return $message;
+};
+
+has path => '/';
+
 sub new {
-  my $self = bless {}, shift;
-  @$self{qw(path message)} = ($_[0] || '/', $_[1] || '');
-  $self;
+  my $class = shift;
+
+  # Constructed with attributes
+  return $class->SUPER::new($_[0]) if ref $_[0] eq 'HASH';
+
+  # Constructed with ($path, ...)
+  my $self = $class->SUPER::new;
+  $self->{path} = shift || '/';
+
+  # Constructed with ($path, $message)
+  $self->message(shift) unless ref $_[0];
+
+  # Constructed with ($path, \@details)
+  $self->details(shift) if ref $_[0];
+
+  return $self;
 }
 
-sub message   { shift->{message} }
-sub path      { shift->{path} }
-sub to_string { sprintf '%s: %s', @{$_[0]}{qw(path message)} }
-sub TO_JSON   { {message => $_[0]->{message}, path => $_[0]->{path}} }
+sub to_string { sprintf '%s: %s', $_[0]->path, $_[0]->message }
+sub TO_JSON { {message => $_[0]->message, path => $_[0]->path} }
 
 1;
 
@@ -34,11 +110,44 @@ L<JSON::Validator>.
 
 =head1 ATTRIBUTES
 
+=head2 details
+
+  my $error     = $error->details(["generic", "generic"]);
+  my $error     = $error->details([qw(array type object)]);
+  my $error     = $error->details([qw(format date-time Invalid)]);
+  my $array_ref = $error->details;
+
+Details about the error:
+
+=over 2
+
+=item 1.
+
+Often the category of tests that was run. Example values: allOf, anyOf, array,
+const, enum, format, integer, not, null, number, object, oneOf and string.
+
+=item 2.
+
+Often the test that failed. Example values: additionalItems,
+additionalProperties, const, enum, maxItems, maxLength, maxProperties, maximum,
+minItems, minLength.  minProperties, minimum, multipleOf, not, null, pattern,
+required, type and uniqueItems,
+
+=item 3.
+
+The rest of the list contains parameters for the test that failed. It can be a
+plain human-readable string or numbers indicating things such as max/min
+values.
+
+=back
+
 =head2 message
 
   my $str = $error->message;
 
-A human readable description of the error. Defaults to empty string.
+A human readable description of the error. Defaults to being being constructed
+from L</details>. See the C<%MESSAGES> variable in the source code for more
+details.
 
 =head2 path
 
@@ -50,7 +159,9 @@ A JSON pointer to where the error occurred. Defaults to "/".
 
 =head2 new
 
-  my $error = JSON::Validator::Error->new($path, $message);
+  my $error = JSON::Validator::Error->new(\%attributes);
+  my $error = JSON::Validator::Error->new($path, \@details);
+  my $error = JSON::Validator::Error->new($path, \@details);
 
 Object constructor.
 

--- a/lib/JSON/Validator/Error.pm
+++ b/lib/JSON/Validator/Error.pm
@@ -3,7 +3,7 @@ use Mojo::Base -base;
 
 use overload q("") => \&to_string, bool => sub {1}, fallback => 1;
 
-our %MESSAGES = (
+our $MESSAGES = {
   allOf => {type => '/allOf Expected %3 - got %4.'},
   anyOf => {type => '/anyOf Expected %3 - got %4.'},
   array => {
@@ -41,7 +41,7 @@ our %MESSAGES = (
     maxLength => 'String is too long: %3/%4.',
     minLength => 'String is too short: %3/%4.',
   }
-);
+};
 
 has details => sub { [qw(generic generic)] };
 
@@ -56,7 +56,7 @@ has message => sub {
   elsif (($details->[1] || '') eq 'type' and @$details == 3) {
     $message = 'Expected %1 - got %3.';
   }
-  elsif (my $group = $MESSAGES{$details->[0]}) {
+  elsif (my $group = $MESSAGES->{$details->[0]}) {
     $message = $group->{$details->[1] || 'default'};
   }
 
@@ -146,8 +146,22 @@ values.
   my $str = $error->message;
 
 A human readable description of the error. Defaults to being being constructed
-from L</details>. See the C<%MESSAGES> variable in the source code for more
+from L</details>. See the C<$MESSAGES> variable in the source code for more
 details.
+
+As an EXPERIMENTAL hack you can localize C<$JSON::Validator::Error::MESSAGES>
+to get i18n support. Example:
+
+  sub validate_i18n {
+    local $JSON::Validator::Error::MESSAGES = {
+      allOf => {type => '/allOf Forventet %3 - fikk %4.'},
+    };
+
+    my @error_norwegian = $jv->validate({age => 42});
+  }
+
+Note that the error messages might contain a mix of English and the local
+language. Run some tests to see how it looks.
 
 =head2 path
 

--- a/t/coerce-default.t
+++ b/t/coerce-default.t
@@ -30,11 +30,11 @@ is_deeply $data, {tos => true, subscribed_to => []},
 
 $jv->schema({
   type       => 'object',
-  properties => {tos => {type => 'boolean', default => 'invalid'}},
+  properties => {age => {type => 'number', default => 'invalid'}},
 });
 
 @errors = $jv->validate({});
-is $errors[0]{message}, 'Expected boolean - got string.',
+is $errors[0]->message, 'Expected number - got string.',
   'default values must be valid';
 
 done_testing;


### PR DESCRIPTION
### Summary
This change involves adding `details()` to the error object, so that you can inspect and a data structure to see what went wrong, instead of looking at `message()`

### Motivation
The motivation behind this is to give the users of JSON::Validator a chance to investigate the cause of an error programatically.

### References
* https://github.com/mojolicious/json-validator/pull/86
* https://github.com/mojolicious/json-validator/issues/129
* https://github.com/mojolicious/json-validator/pull/130