### PR TITLE
Add support for OpenAPI3 nullable property

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -550,6 +550,8 @@ sub _validate {
   $data = $$to_json if $to_json;
   $type = $schema->{type} || _guess_schema_type($schema, $data);
 
+  return if !defined $data and $schema->{nullable};
+
   # Test base schema before allOf, anyOf or oneOf
   if (ref $type eq 'ARRAY') {
     push @{$self->{temp_schema}}, [map { +{%$schema, type => $_} } @$type];

--- a/t/jv-nullable.t
+++ b/t/jv-nullable.t
@@ -1,0 +1,28 @@
+use lib '.';
+use t::Helper;
+
+sub j { Mojo::JSON::decode_json(Mojo::JSON::encode_json($_[0])); }
+
+my $schema = {
+  type => 'object',
+  properties => {
+    nick => {type => 'string'}
+  }
+};
+
+validate_ok {nick => 'batman'}, $schema;
+validate_ok {nick => undef}, $schema,
+  E('/nick', 'Expected string - got null.');
+
+$schema->{properties}{nick}{nullable} = true;
+
+validate_ok {nick => 'batman'}, $schema;
+validate_ok {nick => undef}, $schema;
+
+delete $schema->{properties}{nick}{nullable};
+
+validate_ok {nick => 'batman'}, $schema;
+validate_ok {nick => undef}, $schema,
+  E('/nick', 'Expected string - got null.');
+
+done_testing;


### PR DESCRIPTION
### Summary
This is an attempt to implement support for OpenAPI3 nullable property.
Beware! It is a "works-for-me" patch.

### Motivation
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#fixed-fields-20
is currently broken in `JSON::Validator`.

### References
https://github.com/jhthorsen/mojolicious-plugin-openapi/issues/106
