### PR TITLE
Created method JSON::Validator->set_format_validator

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -193,8 +193,7 @@ sub validate_json {
   __PACKAGE__->singleton->schema($_[1])->validate($_[0]);
 }
 
-sub _build_formats {
-  return {
+my $_default_formats = {
     'date'          => JSON::Validator::Formats->can('check_date'),
     'date-time'     => JSON::Validator::Formats->can('check_date_time'),
     'email'         => JSON::Validator::Formats->can('check_email'),
@@ -214,7 +213,21 @@ sub _build_formats {
     'uri-reference' => JSON::Validator::Formats->can('check_uri_reference'),
     'uri-reference' => JSON::Validator::Formats->can('check_uri_reference'),
     'uri-template'  => JSON::Validator::Formats->can('check_uri_template'),
-  };
+};
+
+sub _build_formats {
+    my ($self) = @_;
+    if (!$$self{_default_formats}) {
+	$$self{_default_formats} = {%$_default_formats};
+    }
+
+    return $$self{_default_formats};
+}
+
+sub set_format_validator {
+    my ($self, $format, $validator) = @_;
+    my $formats = $self->_build_formats;
+    $formats->{$format} = $validator;
 }
 
 sub _get {
@@ -1407,6 +1420,12 @@ An URL (without a recognized scheme) will be treated as a path to a file on
 disk.
 
 =back
+
+=head2 set_format_validator
+
+  $validator->set_format_validator('email' => JSON::Validator::Formats->can('check_email'));
+
+Used to set a custom format validator or replace a default one.
 
 =head2 singleton
 


### PR DESCRIPTION
The method JSON::Validator->set_format_validator lets you set custom format validators or replace a default one.

### Summary
To achieve my objective I moved $_default_formats hash outside the method JSON::Validator->_build_formats to prevent new hash from being created everytime the method gets called.

Then modified JSON::Validator->_build_formats to make a copy of the hash on the object that called the method. The reason I made this change is so each object created can have their own format validators.

FInally, I created the method JSON::Validator->set_format_validator which simply sets the validator subroutine for the given format on the current object.

### Motivation
While using the module in a personal project I had some issues with how the email and uri formats were validated. I managed to create a workaround by overriding the JSON::Validator->_build_format method with modules that specialize validating those formats (Email::Valid and Data::Validate::URI) . I figured it could be useful to change the format validators, so here we are.

### References
https://github.com/mojolicious/json-validator/issues/68


[test.pl.txt](https://github.com/mojolicious/json-validator/files/2871130/test.pl.txt)
