### PR TITLE
pod and cache test fixes

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -1294,7 +1294,7 @@ Used to create a new schema, where the C<$ref> are resolved. C<%args> can have:
 
 =over 2
 
-=item * C<{replace => 1}>
+=item * C<< {replace => 1} >>
 
 Used if you want to replace the C<$ref> inline in the schema. This currently
 does not work if you have circular references. The default is to move all the
@@ -1307,7 +1307,7 @@ on how a C<$ref> looks before and after:
   {"$ref":"http://example.com#/foo/bar"}
      => {"$ref":"#/definitions/_http___example_com-_foo_bar"}
 
-=item * C<{schema => {...}}>
+=item * C<< {schema => {...}} >>
 
 Default is to use the value from the L</schema> attribute.
 

--- a/t/issue-42-cache-control.t
+++ b/t/issue-42-cache-control.t
@@ -5,14 +5,15 @@ use Mojo::File 'tempdir';
 
 plan skip_all => 'TEST_ONLINE=1' unless $ENV{TEST_ONLINE};
 
-$ENV{JSON_VALIDATOR_CACHE_DIR} = '/tmp/whatever';
+$ENV{JSON_VALIDATOR_CACHE_PATH} = '/tmp/whatever';
 my $validator = JSON::Validator->new;
 my @old_files = get_cached_files($validator);
 
 is $validator->cache_paths->[0], '/tmp/whatever', 'back compat env';
 shift @{$validator->cache_paths};
 
-$validator->schema('https://za.payprop.com/api/docs/api_spec.yaml');
+my $spec_url = 'https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/schemas/v2.0/schema.json';
+$validator->schema($spec_url);
 my @new_files = get_cached_files($validator);
 ok @old_files == @new_files, 'remote file not cached in default cache dir';
 
@@ -20,7 +21,7 @@ my $tempdir = tempdir;
 $ENV{JSON_VALIDATOR_CACHE_PATH} = join ':', $tempdir->dirname, '/tmp/whatever';
 $validator = JSON::Validator->new;
 is $validator->cache_paths->[0], $tempdir->dirname, 'env';
-$validator->schema('https://za.payprop.com/api/docs/api_spec.yaml');
+$validator->schema($spec_url);
 @new_files = get_cached_files($validator);
 ok @new_files > @old_files,
   'remote file cached when cache_paths not the default'


### PR DESCRIPTION
- minor pod markup fixes
- fix a test that seems to have been overlooked because it doesn't normally run: an old environment variable was being used, and the spec URL no longer worked.

replaces parts of #150.