### PR TITLE
Extract $schema from document

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl distribution JSON-Validator
 
+ - load_and_validate_schema() now also looks for the schema version in the "$schema"
+   key of the provided document
+
 3.11 2019-05-07T21:53:16+0700
  - Bundle https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v3.0/schema.json #157
 

--- a/t/id-keyword-draft6.t
+++ b/t/id-keyword-draft6.t
@@ -1,0 +1,43 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+use JSON::Validator;
+
+use Mojolicious::Lite;
+get '/person'           => 'person';
+get '/invalid-relative' => 'invalid-relative';
+
+my $t  = Test::Mojo->new;
+my $jv = JSON::Validator->new(ua => $t->ua);
+
+$t->get_ok('/person.json')->status_is(200);
+my $base_url = $t->tx->req->url->to_abs->path('/');
+eval {
+  $jv->load_and_validate_schema("${base_url}person.json",
+    {schema => 'http://json-schema.org/draft-06/schema'});
+};
+ok !$@, "${base_url}schema.json" or diag $@;
+
+is $jv->version, 6,    'detected version from $arg, as draft-06';
+is $jv->_id_key, 'id', 'detected id_key from $arg, as draft-06';
+
+eval { $jv->load_and_validate_schema("${base_url}invalid-relative.json") };
+ok !$@, 'Root id can be relative' or diag $@;
+
+done_testing;
+
+__DATA__
+@@ invalid-relative.json.ep
+{"$id": "whatever"}
+@@ person.json.ep
+{
+  "$id": "http://example.com/person.json",
+  "definitions": {
+    "Person": {
+      "type": "object",
+      "properties": {
+        "firstName": { "type": "string" }
+      }
+    }
+  }
+}

--- a/t/version-detection.t
+++ b/t/version-detection.t
@@ -1,0 +1,51 @@
+use Mojo::Base -strict;
+use Test::Mojo;
+use Test::More;
+use JSON::Validator;
+
+use Mojolicious::Lite;
+get '/person' => 'person';
+
+my $t = Test::Mojo->new;
+$t->get_ok('/person.json')->status_is(200);
+my $base_url = $t->tx->req->url->to_abs->path('/');
+my $document = $t->tx->res->json;
+
+{
+  my $jv = JSON::Validator->new;
+
+  eval { $jv->load_and_validate_schema($document); };
+  ok !$@, 'local schema.json' or diag $@;
+
+  is $jv->version, 7,     'detected version from local document, as draft-07';
+  is $jv->_id_key, '$id', 'detected id_key from local document, as draft-07';
+}
+
+{
+  my $jv = JSON::Validator->new(ua => $t->ua);
+
+  eval { $jv->load_and_validate_schema("${base_url}person.json"); };
+  ok !$@, "${base_url}schema.json" or diag $@;
+
+  is $jv->version, 7,     'detected version from document via url, as draft-07';
+  is $jv->_id_key, '$id', 'detected id_key from document via url, as draft-07';
+}
+
+done_testing;
+
+__DATA__
+@@ invalid-relative.json.ep
+{"$id": "whatever"}
+@@ person.json.ep
+{
+  "$schema":"http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/person.json",
+  "definitions": {
+    "Person": {
+      "type": "object",
+      "properties": {
+        "firstName": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Also infer the schema from the "$schema" key in the document, when available.  Previously, when using a schema document that was downloaded from an external source, only the `$args` variable was used to determine the schema's version; we did not also look inside the document for a `$schema` key.  Now we do both, deferring the second check until after the document has been downloaded and parsing begins.

replaces parts of #150.