### PR TITLE
Avoid x-bundled and ugly definition names

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,10 @@
 Revision history for perl distribution JSON-Validator
 
+3.09 Not Released
+ - Prettier definition names from bundle().
+ - Replaced bundle() argument "ref_key" with "def_location".
+ - Changed default bundle() def_location to "definitions".
+
 3.08 2019-04-06T15:07:11+0700
  - Add support for "default" in object definitions #155
  - Add support for coerce("bool,def,num,str") as alternative to hash

--- a/Changes
+++ b/Changes
@@ -2,8 +2,9 @@ Revision history for perl distribution JSON-Validator
 
 3.09 Not Released
  - Prettier definition names from bundle().
- - Replaced bundle() argument "ref_key" with "def_location".
- - Changed default bundle() def_location to "definitions".
+ - Changed default bundle() definitions location from "x-bundle" to "definitions".
+ - Deprecated bundle({ref_ref => ...})
+ - Deprecated bundle({replace => ...})
 
 3.08 2019-04-06T15:07:11+0700
  - Add support for "default" in object definitions #155

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -233,7 +233,9 @@ sub _definitions_key {
   # No need to rewrite, when it already has a nice name
   return $1
     if $ref->fqn =~ m!#/$DEFINITIONS/([^/]+)$!
-    and ($seen->{$ref->fqn} or !$bundle->{$DEFINITIONS}{$1});
+    and ($seen->{$ref->fqn}
+    or !$bundle->{$DEFINITIONS}{$1}
+    or D($ref->schema) eq D($bundle->{$DEFINITIONS}{$1}));
 
   # Must mask path to file on disk
   my $key       = $ref->fqn;

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -53,7 +53,7 @@ is $jv->schema->get('/name/type'), 'string', 'schema get /name/type';
 is $jv->schema->get('/name/$ref'), '#/definitions/name',
   'schema get /name/$ref';
 
-$bundled = $jv->schema('data://main/api.json')->bundle;
+$bundled = $jv->schema('data://main/bundled.json')->bundle;
 is_deeply [sort keys %{$bundled->{definitions}}], ['objtype'],
   'no dup definitions';
 
@@ -85,7 +85,7 @@ is $bundled->{properties}{age}{description}, 'Age in years',
   or diag explain $bundled;
 
 note 'extract subset of schema';
-$jv->schema('data://main/api.json');
+$jv->schema('data://main/bundled.json');
 $bundled = $jv->bundle({schema => $jv->get([qw(paths /withdots get)])});
 is_deeply(
   $bundled,
@@ -112,21 +112,21 @@ is_deeply [grep { 0 == index $_, $ref_name_prefix } @definitions], [],
 done_testing;
 
 __DATA__
-@@ api.json
+@@ bundled.json
 {
-   "definitions" : {
-      "objtype" : {
-         "type" : "object",
-         "properties" : { "propname" : { "type" : "string" } }
+  "definitions": {
+    "objtype": {
+      "type": "object",
+      "properties": {"propname": {"type": "string"}}
+    }
+  },
+  "paths": {
+    "/withdots": {
+      "get": {
+        "responses": {
+          "200": {"schema": {"$ref": "#/definitions/objtype"}}
+        }
       }
-   },
-   "paths" : {
-      "/withdots" : {
-         "get" : {
-            "responses" : {
-               "200" : { "schema" : { "$ref" : "#/definitions/objtype" } }
-            }
-         }
-      }
-   }
+    }
+  }
 }

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -38,12 +38,11 @@ for my $n (1 .. 3) {
   })->bundle({ref_key => 'definitions'});
   is $bundled->{definitions}{name}{type}, 'string',
     "[$n] name still in definitions";
-  is $bundled->{definitions}{b_json__definitions_age}{type}, 'integer',
-    "[$n] added to definitions";
+  is $bundled->{definitions}{age}{type}, 'integer', "[$n] added to definitions";
   isnt $bundled->{age}, $jv->schema->get('/age'),  "[$n] new age ref";
   is $bundled->{name},  $jv->schema->get('/name'), "[$n] same name ref";
-  is $bundled->{age}{'$ref'}, '#/definitions/b_json__definitions_age',
-    "[$n] age \$ref point to /definitions/b_json__definitions_age";
+  is $bundled->{age}{'$ref'}, '#/definitions/age',
+    "[$n] age \$ref point to /definitions/age";
   is $bundled->{name}{'$ref'}, '#/definitions/name',
     "[$n] name \$ref point to /definitions/name";
 }
@@ -70,9 +69,9 @@ for my $pathlist (@pathlists) {
   is_deeply [sort map { s!^[a-z0-9]{10}!SHA!; $_ }
       keys %{$bundled->{definitions}}],
     [qw(
-      SHA-age.json
-      SHA-unit.json
-      SHA-weight.json
+      SHA-age_json
+      SHA-unit_json
+      SHA-weight_json
       height
       )],
     'right definitions in disk spec'
@@ -96,15 +95,10 @@ is_deeply(
   $bundled,
   {
     definitions => {
-      data___main_api_json__definitions_objtype =>
+      objtype =>
         {properties => {propname => {type => 'string'}}, type => 'object'}
     },
-    responses => {
-      200 => {
-        schema =>
-          {'$ref' => '#/definitions/data___main_api_json__definitions_objtype'}
-      }
-    }
+    responses => {200 => {schema => {'$ref' => '#/definitions/objtype'}}}
   },
   'subset of schema was bundled'
 ) or diag explain $bundled;


### PR DESCRIPTION
### Summary
This pull request improves the definition names created by the bundle() method.

### Motivation
The motivation is that there's no need to create confusing definition names, if there are no conflict with the bundled schema.

### References
* https://github.com/jhthorsen/mojolicious-plugin-openapi/issues/117
* https://github.com/jhthorsen/mojolicious-plugin-openapi/pull/126

Please review the changes @augensalat, @karenetheridge and @mohawk2.