### PR TITLE
Access to schema fragment from custom format codeblocks

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -746,7 +746,7 @@ sub _validate_format {
   my $code = $self->formats->{$schema->{format}};
   return do { warn "Format rule for '$schema->{format}' is missing"; return }
     unless $code;
-  return unless my $err = $code->($value);
+  return unless my $err = $code->($value,$schema);
   return E $path, $err;
 }
 
@@ -1291,7 +1291,10 @@ See L</Bundled specifications> for more details.
   my $jv = $jv->formats(\%hash);
 
 Holds a hash-ref, where the keys are supported JSON type "formats", and
-the values holds a code block which can validate a given format. A code
+the values holds a code block which can validate a value against a given
+format. The second parameter is the schema fragment where the format is
+defined, in case some custom format requires accessing additional schema
+attributes in order to tweak its validation. A code
 block should return C<undef> on success and an error string on error:
 
   sub { return defined $_[0] && $_[0] eq "42" ? undef : "Not the answer." };

--- a/t/custom-formats.t
+++ b/t/custom-formats.t
@@ -3,43 +3,47 @@ use t::Helper;
 use Mojo::Util 'decode';
 use Test::More;
 
-my $schema = {type => 'object', properties => {v => {type => 'string'}}};
+my $palindrome_schema = {
+  type       => 'object',
+  properties => {v => {type => 'string', format => 'palindrome'}}
+};
 
 {
-  local $schema->{properties}{v}{format} = 'palindrome';
-  
   my $check_palindrome = sub {
     return $_[0] eq reverse($_[0]) ? undef : 'Not a palindrome.';
   };
-  
-  validate_custom_format_ok {v => 'Able was I ere I saw elbA'}, $schema, 'palindrome', $check_palindrome;
-  
-  validate_custom_format_ok {v => 'Amoeba'}, $schema,
-    'palindrome', $check_palindrome, E('/v', 'Not a palindrome.');
+
+  validate_custom_format_ok {v => 'Able was I ere I saw elbA'},
+    $palindrome_schema, 'palindrome', $check_palindrome;
+
+  validate_custom_format_ok {v => 'Amoeba'}, $palindrome_schema, 'palindrome',
+    $check_palindrome, E('/v', 'Not a palindrome.');
 }
 
+my $divisible_schema = {
+  type => 'object',
+  properties =>
+    {v => {type => 'integer', format => 'divisible', factors => [3, 5]}}
+};
+
 {
-  local $schema->{properties}{v}{type} = 'integer';
-  local $schema->{properties}{v}{format} = 'divisible';
-  local $schema->{properties}{v}{factors} = [ 3 , 5 ];
-  
   my $check_divisible = sub {
     my $factors = $_[1]->{factors};
     foreach my $factor (@{$factors}) {
-      return 'Not divisible by '.$factor.'.'  if($_[0] % $factor != 0);
+      return 'Not divisible by ' . $factor . '.' if ($_[0] % $factor != 0);
     }
-    
+
     return undef;
   };
-  
-  validate_custom_format_ok {v => 15}, $schema,
-    'divisible', $check_divisible;
-  
-  validate_custom_format_ok {v => 21}, $schema,
-    'divisible', $check_divisible, E('/v', 'Not divisible by 5.');
-  
-  validate_custom_format_ok {v => 20}, $schema,
-    'divisible', $check_divisible, E('/v', 'Not divisible by 3.');
+
+  validate_custom_format_ok {v => 15}, $divisible_schema, 'divisible',
+    $check_divisible;
+
+  validate_custom_format_ok {v => 21}, $divisible_schema, 'divisible',
+    $check_divisible, E('/v', 'Not divisible by 5.');
+
+  validate_custom_format_ok {v => 20}, $divisible_schema, 'divisible',
+    $check_divisible, E('/v', 'Not divisible by 3.');
 }
 
 done_testing;

--- a/t/custom-formats.t
+++ b/t/custom-formats.t
@@ -1,0 +1,45 @@
+use lib '.';
+use t::Helper;
+use Mojo::Util 'decode';
+use Test::More;
+
+my $schema = {type => 'object', properties => {v => {type => 'string'}}};
+
+{
+  local $schema->{properties}{v}{format} = 'palindrome';
+  
+  my $check_palindrome = sub {
+    return $_[0] eq reverse($_[0]) ? undef : 'Not a palindrome.';
+  };
+  
+  validate_custom_format_ok {v => 'Able was I ere I saw elbA'}, $schema, 'palindrome', $check_palindrome;
+  
+  validate_custom_format_ok {v => 'Amoeba'}, $schema,
+    'palindrome', $check_palindrome, E('/v', 'Not a palindrome.');
+}
+
+{
+  local $schema->{properties}{v}{type} = 'integer';
+  local $schema->{properties}{v}{format} = 'divisible';
+  local $schema->{properties}{v}{factors} = [ 3 , 5 ];
+  
+  my $check_divisible = sub {
+    my $factors = $_[1]->{factors};
+    foreach my $factor (@{$factors}) {
+      return 'Not divisible by '.$factor.'.'  if($_[0] % $factor != 0);
+    }
+    
+    return undef;
+  };
+  
+  validate_custom_format_ok {v => 15}, $schema,
+    'divisible', $check_divisible;
+  
+  validate_custom_format_ok {v => 21}, $schema,
+    'divisible', $check_divisible, E('/v', 'Not divisible by 5.');
+  
+  validate_custom_format_ok {v => 20}, $schema,
+    'divisible', $check_divisible, E('/v', 'Not divisible by 3.');
+}
+
+done_testing;


### PR DESCRIPTION
### Summary
Custom formats codeblocks now receive as second parameter the schema fragment, in case additional attributes are needed to tweak the validation, per schema fragment.

### Motivation
In some of our projects we want to tweak custom formats validation based on values from the schema. 

### References
(none)
