### PR TITLE
turn off -st option, to allow for "perltidy -b $filename"

### DIFF
--- a/.perltidyrc
+++ b/.perltidyrc
@@ -11,3 +11,4 @@
 -sbt=2   # High square bracket tightness
 -wn      # Weld nested containers
 -isbc    # Don't indent comments without leading space
+-nst     # undo -st from -pbp, to allow for command line use


### PR DESCRIPTION
### Summary
Now it's possible for the user to run perltidy manually.

### Motivation
Because perltidy is mandatory for getting patches into this repository :)

### References
none.
