### PR TITLE
Bugfix: use time local

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -15,7 +15,6 @@ use Mojo::Loader;
 use Mojo::URL;
 use Mojo::Util qw(url_unescape sha1_sum);
 use Scalar::Util qw(blessed refaddr);
-use Time::Local ();
 
 use constant CASE_TOLERANT     => File::Spec->case_tolerant;
 use constant COLORS            => eval { require Term::ANSIColor };

--- a/lib/JSON/Validator/Formats.pm
+++ b/lib/JSON/Validator/Formats.pm
@@ -1,6 +1,8 @@
 package JSON::Validator::Formats;
 use Mojo::Base -strict;
 
+require Time::Local;
+
 use constant DATA_VALIDATE_DOMAIN => eval 'require Data::Validate::Domain;1';
 use constant DATA_VALIDATE_IP     => eval 'require Data::Validate::IP;1';
 use constant NET_IDN_ENCODE       => eval 'require Net::IDN::Encode;1';

--- a/lib/JSON/Validator/Formats.pm
+++ b/lib/JSON/Validator/Formats.pm
@@ -195,7 +195,7 @@ sub _module_missing {
 
 =head1 NAME
 
-JSON::Validator::Formats - Functions for valiating JSON schema formats
+JSON::Validator::Formats - Functions for validating JSON schema formats
 
 =head1 SYNOPSIS
 
@@ -219,6 +219,7 @@ JSON::Validator::Formats - Functions for valiating JSON schema formats
 
 L<JSON::Validator::Formats> is a module with utility functions used by
 L<JSON::Validator/formats> to match JSON Schema formats.
+All functions return C<undef> for success or an error message for failure.
 
 =head1 FUNCTIONS
 

--- a/t/formats.t
+++ b/t/formats.t
@@ -1,0 +1,10 @@
+use strict;
+use Test::More;
+
+BEGIN { use_ok ('JSON::Validator::Formats'); }
+
+ok !JSON::Validator::Formats::check_date('2019-06-11');
+ok !JSON::Validator::Formats::check_email('doe@example.org');
+ok !JSON::Validator::Formats::check_time('08:22:54');
+
+done_testing;


### PR DESCRIPTION
### Summary

Date/time checks in `JSON::Validator::Formats` are failing because `Time::Local` is not loaded.

### Motivation
Because it must not fail.

### References
I added a min-test for demonstration.