### PR TITLE
Clean up deprecated internal call

### DIFF
--- a/lib/JSON/Validator/Joi.pm
+++ b/lib/JSON/Validator/Joi.pm
@@ -81,7 +81,7 @@ sub uri       { shift->_type('string')->format('uri') }
 
 sub validate {
   my ($self, $data) = @_;
-  state $jv = JSON::Validator->new->coerce(1);
+  state $jv = JSON::Validator->new->coerce({booleans => 1, numbers => 1, strings => 1});
   return $jv->validate($data, $self->compile);
 }
 


### PR DESCRIPTION
### Summary
Replaces an instance of deprecated API usage with its proper equivalent.

### Motivation
When you call JSON::Validator::Joi::validate you get a deprecation warning from another part of JSON::Validator. That's not right.