### PR TITLE
fix copy required

### DIFF
--- a/lib/JSON/Validator/Joi.pm
+++ b/lib/JSON/Validator/Joi.pm
@@ -48,7 +48,7 @@ sub extend {
   }
 
   push @{ $clone->{required} }, @{ $self->{required} }
-    if $self->{required} && @{ $self->{required} };
+    if $self->{required} && @{$self->{required}};
 
   return $clone;
 }
@@ -73,6 +73,8 @@ sub props {
     push @{$self->{required}}, $name if $property->{required};
     $self->{properties}{$name} = $property->compile;
   }
+  @{$self->{required}} = sort @{$self->{required}}
+    if $self->{required} && @{$self->{required}};
 
   return $self;
 }

--- a/lib/JSON/Validator/Joi.pm
+++ b/lib/JSON/Validator/Joi.pm
@@ -47,6 +47,9 @@ sub extend {
       for keys %{$self->{properties} || {}};
   }
 
+  push @{ $clone->{required} }, @{ $self->{required} }
+    if $self->{required} && @{ $self->{required} };
+
   return $clone;
 }
 

--- a/t/joi.t
+++ b/t/joi.t
@@ -119,6 +119,36 @@ is_deeply(
 );
 
 is_deeply(
+  edj(
+    joi->object->props(x => joi->integer, y => joi->integer->required)
+      ->extend(
+        joi->object->props(
+            k => joi->object->props(
+                x => joi->string->required,
+                y => joi->string->required
+            )
+        )
+     )
+  ),
+  {
+    type       => 'object',
+    properties => {
+      x => {type => 'integer'},
+      y => {type => 'integer'},
+      k => {
+        type => 'object',
+        properties => {
+          x => {type => 'string'}, y => {type => 'string'},
+        },
+        required => ['y','x']
+      }
+    },
+    required   => ['k','y'],
+  },
+  'extended object',
+);
+
+is_deeply(
   edj(joi->object->props(
     ip => joi->type([qw(string null)])->format('ip'),
     ns => joi->string

--- a/t/joi.t
+++ b/t/joi.t
@@ -140,7 +140,7 @@ is_deeply(
         properties => {
           x => {type => 'string'}, y => {type => 'string'},
         },
-        required => ['y','x']
+        required => ['x', 'y']
       }
     },
     required   => ['k','y'],


### PR DESCRIPTION
Hello 
required dont copy

```
   my $joi = joi->object->props(
        some1 => joi->string->enum([qw/asf fgfg/])->required,
        some2 => joi->string->min(1)->required,
    );
    my $joi_recipient = joi->object->props(
        some3 => joi->object->props(
            some4 => joi->string->min(1)->required,  
            some5 => joi->string->enum([qw/asfd dfdf/]->required
        )
    );
    $joi = $joi->extend( $joi_recipient );
```

required was in first $joi dont by in finish $joi 



my $new_joi = $joi->extend($joi);
Will extend $joi with the definitions in $joi and return a new object.

It is not clear which will be expanded - $jio or $jio ))

my $new_joi = $joi->extend($joi_new);
I think that $joi_new added to $joi and $joi_new remained the same as before


I added the second to the first, and the second remained the same. Not this way?

rebless $self in extend. Why?