### PR TITLE
new way to obfuscate file path

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -239,8 +239,9 @@ sub _definitions_key {
   my $key       = $ref->fqn;
   my $spec_path = (split '#', $key)[0];
   if (-e $spec_path) {
-    $key = sprintf '%s-%s', substr(sha1_sum($key), 0, 10),
-      path($spec_path)->basename;
+    my ($name) = ($key =~ m!$spec_path#/$DEFINITIONS/([^/]+)$!);
+    $name //= path($spec_path)->basename;
+    $key = sprintf '%s-%s', $name, substr(sha1_sum($key), 0, 10);
   }
 
   # Fallback or nicer path name


### PR DESCRIPTION
### Summary
Improve readability of doc page generated by Mojolicious::Plugin::OpenAPI

### Motivation
Current way leads to unreadable definition names and doesn't hide filenames.

Compare 
![before](https://user-images.githubusercontent.com/5188593/64074876-b3dafc80-ccb9-11e9-896c-0e9d1597064f.jpg)
and
![after](https://user-images.githubusercontent.com/5188593/64074875-b3dafc80-ccb9-11e9-856d-054126273cfb.jpg)
