### PR TITLE
Add support for changing definitions path when working with $ref

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -102,7 +102,7 @@ sub bundle {
       unless ($self->{seen_ref}{$tied->fqn}++) {
         push @topics,
           [_node($schema, $path, 1, 0) || {}, _node($bundle, $path, 1, 1)];
-        push @topics, [$tied->schema, $bundle->{$path->[0]}{$path->[1]} ||= {}];
+        push @topics, [$tied->schema, _node($bundle, $path, 0, 1)];
       }
 
       $path = join '/', '#', @$path;

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -1323,7 +1323,7 @@ See L<JSON::Validator::Formats> for a list of supported formats.
 =head2 generate_definitions_path
 
   my $cb = $self->generate_definitions_path;
-  my $jv = $self->generate_definitions_path(sub { my $ref = shift; return ["definitions" });
+  my $jv = $self->generate_definitions_path(sub { my $ref = shift; return ["definitions"] });
 
 Holds a callback that is used by L</bundle> to figure out where to place
 references. The default location is under "definitions", but this can be

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -21,37 +21,40 @@ for my $n (1 .. 3) {
   $bundled = $jv->bundle({
     replace => 1,
     schema  => {
-      name        => {'$ref' => '#/definitions/name'},
-      definitions => {name   => {type => 'string'}}
+      definitions => {name   => {type => 'string'}},
+      surname     => {'$ref' => '#/definitions/name'},
     },
   });
 
-  is $bundled->{name}{type}, 'string', "[$n] replace=1";
+  is $bundled->{surname}{type}, 'string', "[$n] replace=1";
 
   note "[$n] replace=0";
   $bundled = $jv->schema({
-    name        => {'$ref' => '#/definitions/name'},
-    age         => {'$ref' => 'b.json#/definitions/age'},
+    surname     => {'$ref' => '#/definitions/name'},
+    age         => {'$ref' => 'b.json#/definitions/years'},
     definitions => {name   => {type => 'string'}},
-    B => {id => 'b.json', definitions => {age => {type => 'integer'}}},
+    B => {id => 'b.json', definitions => {years => {type => 'integer'}}},
   })->bundle;
+  ok $bundled->{definitions}{name},
+    "[$n] definitions/name still in definitions";
   is $bundled->{definitions}{name}{type}, 'string',
-    "[$n] name still in definitions";
-  is $bundled->{definitions}{age}{type}, 'integer', "[$n] added to definitions";
-  isnt $bundled->{age}, $jv->schema->get('/age'),  "[$n] new age ref";
-  is $bundled->{name},  $jv->schema->get('/name'), "[$n] same name ref";
-  is $bundled->{age}{'$ref'}, '#/definitions/age',
-    "[$n] age \$ref point to /definitions/age";
-  is $bundled->{name}{'$ref'}, '#/definitions/name',
-    "[$n] name \$ref point to /definitions/name";
+    "[$n] definitions/name/type still in definitions";
+  is $bundled->{definitions}{years}{type}, 'integer',
+    "[$n] added to definitions";
+  isnt $bundled->{age},   $jv->schema->get('/age'),     "[$n] new age ref";
+  is $bundled->{surname}, $jv->schema->get('/surname'), "[$n] same surname ref";
+  is $bundled->{age}{'$ref'}, '#/definitions/years',
+    "[$n] age \$ref point to /definitions/years";
+  is $bundled->{surname}{'$ref'}, '#/definitions/name',
+    "[$n] surname \$ref point to /definitions/name";
 }
 
-is $jv->get([qw(name type)]), 'string', 'get /name/$ref';
-is $jv->get('/name/type'), 'string', 'get /name/type';
-is $jv->get('/name/$ref'), undef,    'get /name/$ref';
-is $jv->schema->get('/name/type'), 'string', 'schema get /name/type';
-is $jv->schema->get('/name/$ref'), '#/definitions/name',
-  'schema get /name/$ref';
+is $jv->get([qw(surname type)]), 'string', 'get /surname/$ref';
+is $jv->get('/surname/type'), 'string', 'get /surname/type';
+is $jv->get('/surname/$ref'), undef,    'get /surname/$ref';
+is $jv->schema->get('/surname/type'), 'string', 'schema get /surname/type';
+is $jv->schema->get('/surname/$ref'), '#/definitions/name',
+  'schema get /surname/$ref';
 
 $bundled = $jv->schema('data://main/bundled.json')->bundle;
 is_deeply [sort keys %{$bundled->{definitions}}], ['objtype'],
@@ -67,11 +70,11 @@ for my $pathlist (@pathlists) {
   is_deeply [sort map { s!^[a-z0-9]{10}!SHA!; $_ }
       keys %{$bundled->{definitions}}],
     [qw(
-      SHA-age_json
-      SHA-unit_json
-      SHA-weight_json
-      height
-      )],
+    SHA-age_json
+    SHA-unit_json
+    SHA-weight_json
+    height
+    )],
     'right definitions in disk spec'
     or diag explain $bundled->{definitions};
 }

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -125,8 +125,6 @@ $bundled = $jv->bundle;
 is @deep,  2, 'even deeper present' or diag join ', ', @deep;
 is @other, 3, 'other present'       or diag join ', ', @other;
 
-warn Data::Dumper::Dumper($bundled);
-
 done_testing;
 
 __DATA__

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -106,10 +106,14 @@ note 'no leaking path';
 my $ref_name_prefix = $workdir;
 $ref_name_prefix =~ s![^\w-]!_!g;
 $jv->schema(path $workdir, 'spec', 'bundle-no-leaking-filename.json');
-$bundled = $jv->bundle({ref_key => 'xyz'});
-my @definitions = keys %{$bundled->{xyz}};
-ok @definitions, 'definitions are present';
-is_deeply [grep { 0 == index $_, $ref_name_prefix } @definitions], [],
+$jv->generate_definitions_path(
+  sub { [shift->fqn =~ /with-deep-mixed/ ? 'deep' : 'other'] });
+$bundled = $jv->bundle;
+my @deep  = keys %{$bundled->{deep}};
+my @other = keys %{$bundled->{other}};
+is @deep,  2, 'deep present';
+is @other, 3, 'other present';
+is_deeply [grep { 0 == index $_, $ref_name_prefix } @deep, @other], [],
   'no leaking of path';
 
 done_testing;

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -111,10 +111,20 @@ $jv->generate_definitions_path(
 $bundled = $jv->bundle;
 my @deep  = keys %{$bundled->{deep}};
 my @other = keys %{$bundled->{other}};
-is @deep,  2, 'deep present';
-is @other, 3, 'other present';
+is @deep,  2, 'deep present'  or diag join ', ', @deep;
+is @other, 3, 'other present' or diag join ', ', @other;
 is_deeply [grep { 0 == index $_, $ref_name_prefix } @deep, @other], [],
   'no leaking of path';
+
+$jv->generate_definitions_path(
+  sub { shift->fqn =~ /with-deep-mixed/ ? ['even', 'deeper'] : ['other'] });
+$bundled = $jv->bundle;
+@deep    = keys %{$bundled->{even}{deeper}};
+@other   = keys %{$bundled->{other}};
+is @deep,  2, 'even deeper present' or diag join ', ', @deep;
+is @other, 3, 'other present'       or diag join ', ', @other;
+
+warn Data::Dumper::Dumper($bundled);
 
 done_testing;
 


### PR DESCRIPTION
### Summary

Allow for definitions path to be changed, today the default behavior for adding refs into `/definitions/some_def` will render a OpenAPI v3 spec wrongly.

a $ref like `#/components/schemas/myschema` will be rendered as `/definitions/components_schemas_myschema`, which is not valid according the OpenAPI v3 spec

the `generate_definitions_path` function makes it possible to override this behavior, keeping JSON::Validator neutral to the proposed change.

These changes is based on the generate_definitions_path branch, but with a fix for the test

### Motivation

OpenAPIv3 has chosen to rearrange its definitions, into a deeper path as an example `/components/schemas/myschema`

This change makes it possible for modules like Mojolicious::Plugin::OpenAPI to support the v3, with minimal effort

Earlier attempts to make this right eq. #174 was not general enough

Hope that this time around the change is general enough to be accepted 
 
### References

* https://swagger.io/specification/
* Old PR, #174 which also have bit of information on generate_definitions_path 
* PR #175 is not needed if this PR is accepted
* jhthorsen/mojolicious-plugin-openapi/issues/138
