### PR TITLE
Fix for deep recursion on Windows #170

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -547,7 +547,8 @@ sub _location_to_abs {
   # definitely relative now
   if ($base->isa('Mojo::File')) {
     return $base if !length $location;
-    return $base->sibling(split '/', $location)->realpath;
+    my $path = $base->sibling(split '/', $location)->realpath;
+    return CASE_TOLERANT ? lc($path) : $path;
   }
   return $location_as_url->to_abs($base);
 }


### PR DESCRIPTION
# Summary
This is the modified version of #178 by @chorny.

### Motivation
The point of this fix is to use the same type of id as the _load_schema() method returns at [the line 342](https://github.com/mojolicious/json-validator/blob/6ba3427f31a808541afd6fc9b27b04515c2e38f2/lib/JSON/Validator.pm#L342) on a case tolerant file system.

I wanted to add a test that uses MixedCase files but simple mocking of CASE_TOLERANT constant doesn't work under a case intolerant system because _load_schema fails to find the other schema file because of this case lowering. Removing case lowering of the line 342 would also work, but considering of #102, I assume it's better to keep it as is. Maybe we can consider t/more-bundle.t as a required failing test. Some of the Win32 reports say the tests have "pass"ed but that's just because YAML::XS is not installed there and the test is skipped.

### References
#170, #178, #102