### PR TITLE
Ether/validate const

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -635,6 +635,13 @@ sub _validate {
     return @errors if @errors;
   }
 
+  if (exists $schema->{const}) {
+    push @errors,
+      $self->_validate_type_const($to_json ? $$to_json : $_[1], $path, $schema);
+    $self->_report_errors($path, 'enum', \@errors) if REPORT;
+    return @errors if @errors;
+  }
+
   if ($schema->{enum}) {
     push @errors,
       $self->_validate_type_enum($to_json ? $$to_json : $_[1], $path, $schema);

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -1108,7 +1108,7 @@ sub _guess_schema_type {
   return _guessed_right(number => $_[1])
     if defined $_[0]->{maximum}
     or defined $_[0]->{minimum};
-  return 'const' if $_[0]->{const};
+  return 'const' if exists $_[0]->{const};
   return undef;
 }
 

--- a/t/jv-array.t
+++ b/t/jv-array.t
@@ -55,4 +55,9 @@ ok !$jv->validate(\@numbers), 'integers are valid';
 is encode_json(\@numbers), encode_json([1, 2, 1, 1, 3, 1]),
   'coerced into numbers';
 
+my $array_constant = {type => 'array', const => [1, 'a', undef]};
+validate_ok [1, 'a', undef], $array_constant;
+validate_ok [1, 'b', undef], $array_constant,
+  E('/', q{Does not match const: [1,"a",null].});
+
 done_testing;

--- a/t/jv-boolean.t
+++ b/t/jv-boolean.t
@@ -22,9 +22,21 @@ validate_ok j('foo'),             {type => 'boolean'},
   E('/', 'Expected boolean - got string.');
 validate_ok undef, {properties => {}}, E('/', 'Expected object - got null.');
 
+my $bool_constant_false = {type => 'boolean', const => false};
+my $bool_constant_true  = {type => 'boolean', const => true};
+validate_ok false, $bool_constant_false;
+validate_ok true, $bool_constant_false, E('/', q{Does not match const: false.});
+validate_ok true, $bool_constant_true;
+validate_ok false, $bool_constant_true, E('/', q{Does not match const: true.});
+
 jv->coerce('bool');
 validate_ok {nick => 1000}, $schema;
 validate_ok {nick => 0.5},  $schema;
+
+validate_ok 0,    $bool_constant_false;
+validate_ok 1000, $bool_constant_false, E('/', q{Does not match const: false.});
+validate_ok 1000, $bool_constant_true;
+validate_ok 0,    $bool_constant_true, E('/', q{Does not match const: true.});
 
 done_testing;
 

--- a/t/jv-const.t
+++ b/t/jv-const.t
@@ -71,4 +71,12 @@ validate_ok {
   people => [{name => 'mr. chocolate fan', age => 42, likes => 'peanutbutter'}]
 }, $schema;
 
+my $null_const = {const => undef};
+validate_ok 'foo', $null_const, E('/', q{Does not match const: null.});
+validate_ok undef, $null_const;
+
+my $empty_const = {const => ''};
+validate_ok 'foo', $empty_const, E('/', q{Does not match const: "".});
+validate_ok '', $empty_const;
+
 done_testing;

--- a/t/jv-const.t
+++ b/t/jv-const.t
@@ -79,4 +79,9 @@ my $empty_const = {const => ''};
 validate_ok 'foo', $empty_const, E('/', q{Does not match const: "".});
 validate_ok '', $empty_const;
 
+my $array_constant = {const => [1, 'a', undef]};
+validate_ok [1, 'a', undef], $array_constant;
+validate_ok [1, 'b', undef], $array_constant,
+  E('/', q{Does not match const: [1,"a",null].});
+
 done_testing;

--- a/t/jv-integer.t
+++ b/t/jv-integer.t
@@ -18,6 +18,10 @@ validate_ok {mynumber => '2'}, $schema,
 $schema->{properties}{mynumber}{multipleOf} = 2;
 validate_ok {mynumber => 3}, $schema, E('/mynumber', 'Not multiple of 2.');
 
+my $int_constant = {type => 'integer', const => 2};
+validate_ok 2, $int_constant;
+validate_ok 1, $int_constant, E('/', q{Does not match const: 2.});
+
 jv->coerce('num');
 validate_ok {mynumber => '2'},    $schema;
 validate_ok {mynumber => '2xyz'}, $schema,
@@ -25,5 +29,8 @@ validate_ok {mynumber => '2xyz'}, $schema,
 
 $schema->{properties}{mynumber}{minimum} = -3;
 validate_ok {mynumber => '-2'}, $schema;
+
+validate_ok '2', $int_constant;
+validate_ok '1', $int_constant, E('/', q{Does not match const: 2.});
 
 done_testing;

--- a/t/jv-number.t
+++ b/t/jv-number.t
@@ -11,6 +11,10 @@ validate_ok {mynumber => 1},   $schema;
 validate_ok {mynumber => '2'}, $schema,
   E('/mynumber', 'Expected number - got string.');
 
+my $numeric_constant = {type => 'number', const => 2.1};
+validate_ok 2.1, $numeric_constant;
+validate_ok 1, $numeric_constant, E('/', q{Does not match const: 2.1.});
+
 jv->coerce('numbers');
 validate_ok {mynumber => '-0.3'},   $schema;
 validate_ok {mynumber => '0.1e+1'}, $schema;
@@ -23,5 +27,8 @@ validate_ok {validNumber => 2.01},
   type       => 'object',
   properties => {validNumber => {type => 'number', multipleOf => 0.01}}
   };
+
+validate_ok '2.1', $numeric_constant;
+validate_ok '1', $numeric_constant, E('/', q{Does not match const: 2.1.});
 
 done_testing;

--- a/t/jv-object.t
+++ b/t/jv-object.t
@@ -132,4 +132,9 @@ my $obj = bless {age => 'not_a_string'}, 'main';
 validate_ok $obj, {properties => {age => {type => 'integer'}}},
   E('/age', 'Expected integer - got string.', 'age is not a string');
 
+my $object_constant = {type => 'object', const => {a => 1}};
+validate_ok {a => 1}, $object_constant;
+validate_ok {b => 1}, $object_constant,
+  E('/', q{Does not match const: {"a":1}.});
+
 done_testing;

--- a/t/jv-string.t
+++ b/t/jv-string.t
@@ -40,4 +40,12 @@ validate_ok(
   }
 );
 
+my $string_constant = {type => 'string', const => 'foo'};
+validate_ok 'foo', $string_constant;
+validate_ok 'bar', $string_constant, E('/', q{Does not match const: "foo".});
+
+my $empty_string_constant = {type => 'string', const => ''};
+validate_ok '', $empty_string_constant;
+validate_ok 'bar', $empty_string_constant, E('/', q{Does not match const: "".});
+
 done_testing;


### PR DESCRIPTION
### Summary
Validations involving constants were failing:
- `const => ''`, and
- `const => <anything>` combined with an explicit type declaration
... were not having the constant value checked.

(This is easy to verify by commenting out my code changes and observing that the new tests I added do not pass.)