### PR TITLE
fix use of true, false (sub)schemas

### DIFF
--- a/Changes
+++ b/Changes
@@ -47,7 +47,7 @@ Revision history for perl distribution JSON-Validator
 3.09 2019-05-04T22:28:55+0700
  - Prettier definition names from bundle().
  - Changed default bundle() definitions location from "x-bundle" to "definitions".
- - Deprecated bundle({ref_ref => ...})
+ - Deprecated bundle({ref_key => ...})
  - Deprecated bundle({replace => ...})
 
 3.08 2019-04-06T15:07:11+0700

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -503,8 +503,6 @@ sub _validate {
   my ($self, $data, $path, $schema) = @_;
   my ($seen_addr, $to_json, $type);
 
-  # Do not validate against "default" in draft-07 schema
-  return if is_type $schema, 'JSON::PP::Boolean';
 
   $schema    = $self->_ref_to_schema($schema) if $schema->{'$ref'};
   $seen_addr = join ':', refaddr($schema),

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -178,7 +178,7 @@ sub singleton { state $jv = shift->new }
 sub validate {
   my ($self, $data, $schema) = @_;
   $schema ||= $self->schema->data;
-  return E '/', 'No validation rules defined.' unless $schema and %$schema;
+  return E '/', 'No validation rules defined.' unless defined $schema;
 
   local $self->{schema} = Mojo::JSON::Pointer->new($schema);
   local $self->{seen}   = {};
@@ -372,6 +372,7 @@ sub _ref_to_schema {
     confess "Seems like you have a circular reference: @guard"
       if @guard > RECURSION_LIMIT;
     $schema = $tied->schema;
+    last if is_type $schema, 'BOOL';
   }
 
   return $schema;
@@ -399,6 +400,10 @@ sub _resolve {
   }
   elsif ($resolved = $self->{schemas}{$schema // ''}) {
     return $resolved;
+  }
+  elsif (is_type $schema, 'BOOL') {
+    $self->_register_schema($schema, $schema);
+    return $schema;
   }
   else {
     ($schema, $id) = $self->_load_schema($schema);
@@ -476,6 +481,7 @@ sub _resolve_ref {
   my ($fqn, $ref, @guard);
 
   while (1) {
+    last if is_type $other, 'BOOL';
     $ref = $other->{'$ref'};
     push @guard, $other->{'$ref'};
     confess "Seems like you have a circular reference: @guard"
@@ -490,9 +496,10 @@ sub _resolve_ref {
     $other   = $self->_resolve($location);
 
     if (defined $pointer and length $pointer and $pointer =~ m!^/!) {
-      $other = Mojo::JSON::Pointer->new($other)->get($pointer)
-        or confess
-        qq[Possibly a typo in schema? Could not find "$pointer" in "$location" ($ref)];
+      $other = Mojo::JSON::Pointer->new($other)->get($pointer);
+      confess
+        qq[Possibly a typo in schema? Could not find "$pointer" in "$location" ($ref)]
+        if not defined $other;
     }
   }
 
@@ -503,8 +510,10 @@ sub _validate {
   my ($self, $data, $path, $schema) = @_;
   my ($seen_addr, $to_json, $type);
 
+  $schema = $self->_ref_to_schema($schema)
+    if ref $schema eq 'HASH' and $schema->{'$ref'};
+  return $schema ? () : E $path, [not => 'not'] if is_type $schema, 'BOOL';
 
-  $schema    = $self->_ref_to_schema($schema) if $schema->{'$ref'};
   $seen_addr = join ':', refaddr($schema),
     (ref $data ? refaddr $data : ++$self->{seen}{scalar});
 
@@ -763,7 +772,7 @@ sub _validate_type_array {
         [array => additionalItems => int(@$data), int(@rules)];
     }
   }
-  elsif (is_type $schema->{items}, 'HASH') {
+  elsif (exists $schema->{items}) {
     for my $i (0 .. @$data - 1) {
       push @errors, $self->_validate($data->[$i], "$path/$i", $schema->{items});
     }
@@ -868,9 +877,12 @@ sub _validate_type_object {
 
   my $coerce = $self->{coerce}{defaults};
   while (my ($k, $r) = each %{$schema->{properties}}) {
-    next unless ref $r eq 'HASH';
     push @{$rules{$k}}, $r;
-    if ($coerce and exists $r->{default} and !exists $data->{$k}) {
+    if (  $coerce
+      and ref $r eq 'HASH'
+      and exists $r->{default}
+      and !exists $data->{$k})
+    {
       $data->{$k} = $r->{default};
     }
   }
@@ -901,6 +913,7 @@ sub _validate_type_object {
   for my $k (sort keys %rules) {
     for my $r (@{$rules{$k}}) {
       next unless exists $data->{$k};
+      $r = $self->_ref_to_schema($r) if ref $r eq 'HASH' and $r->{'$ref'};
       my @e = $self->_validate($data->{$k}, json_pointer($path, $k), $r);
       push @errors, @e;
       next if @e or !is_type $r, 'HASH';

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -473,7 +473,7 @@ sub _resolve_ref {
   return if tied %$topic;
 
   my $other = $topic;
-  my ($location, $fqn, $pointer, $ref, @guard);
+  my ($fqn, $ref, @guard);
 
   while (1) {
     $ref = $other->{'$ref'};
@@ -482,7 +482,7 @@ sub _resolve_ref {
       if @guard > RECURSION_LIMIT;
     last if !$ref or ref $ref;
     $fqn = $ref =~ m!^/! ? "#$ref" : $ref;
-    ($location, $pointer) = split /#/, $fqn, 2;
+    my ($location, $pointer) = split /#/, $fqn, 2;
     $url     = $location = _location_to_abs($location, $url);
     $pointer = undef if length $location and !length $pointer;
     $pointer = url_unescape $pointer if defined $pointer;

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -1143,8 +1143,8 @@ See L<JSON::Validator::Formats> for a list of supported formats.
 
 =head2 generate_definitions_path
 
-  my $cb = $self->generate_definitions_path;
-  my $jv = $self->generate_definitions_path(sub { my $ref = shift; return ["definitions"] });
+  my $cb = $jv->generate_definitions_path;
+  my $jv = $jv->generate_definitions_path(sub { my $ref = shift; return ["definitions"] });
 
 Holds a callback that is used by L</bundle> to figure out where to place
 references. The default location is under "definitions", but this can be
@@ -1177,11 +1177,11 @@ using L</load_and_validate_schema>, unless already set.
 =head2 bundle
 
   # These two lines does the same
-  my $schema = $jv->bundle({schema => $self->schema->data});
+  my $schema = $jv->bundle({schema => $jv->schema->data});
   my $schema = $jv->bundle;
 
   # Will only bundle a section of the schema
-  my $schema = $jv->bundle({schema => $self->schema->get("/properties/person/age")});
+  my $schema = $jv->bundle({schema => $jv->schema->get("/properties/person/age")});
 
 Used to create a new schema, where there are no "$ref" pointing to external
 resources. This means that all the "$ref" that are found, will be moved into

--- a/lib/JSON/Validator/Ref.pm
+++ b/lib/JSON/Validator/Ref.pm
@@ -43,6 +43,10 @@ JSON::Validator::Ref - JSON::Validator $ref representation
   use JSON::Validator::Ref;
   my $ref = JSON::Validator::Ref->new({ref => "...", schema => {...});
 
+or:
+
+  tie my %ref, 'JSON::Validator::Ref', $schema, $path;
+
 =head1 DESCRIPTION
 
 L<JSON::Validator::Ref> is a class representing a C<$ref> inside a JSON Schema.

--- a/t/Helper.pm
+++ b/t/Helper.pm
@@ -31,6 +31,7 @@ sub validate_ok {
   my $description
     ||= @expected ? "errors: @expected" : "valid: " . encode_json($data);
   my @errors = jv()->schema($schema)->validate($data);
+  local $Test::Builder::Level = $Test::Builder::Level + 1;
   Test::More::is_deeply(
     [map { $_->TO_JSON } sort { $a->path cmp $b->path } @errors],
     [map { $_->TO_JSON } sort { $a->path cmp $b->path } @expected],

--- a/t/jv-array.t
+++ b/t/jv-array.t
@@ -59,4 +59,43 @@ validate_ok [1, 'a', undef], $array_constant;
 validate_ok [1, 'b', undef], $array_constant,
   E('/', q{Does not match const: [1,"a",null].});
 
+# TODO! true, false are draft 6+ only
+validate_ok [1, 'foo', 1.2], {type => 'array', items => {}};
+validate_ok [1, 'foo', 1.2], {type => 'array', items => true};
+
+validate_ok [1, 'foo', 1.2], {type => 'array', items => [true, true, false]},
+  E('/2', 'Should not match.');
+
+validate_ok [1, 'foo', 1.2], {type => 'array', items => false},
+  E('/0', 'Should not match.'), E('/1', 'Should not match.'),
+  E('/2', 'Should not match.');
+
+validate_ok [1, 'foo', 1.2],
+  {
+  definitions => {my_true_ref => true},
+  type        => 'array',
+  items       => {'$ref' => '#/definitions/my_true_ref'},
+  };
+
+validate_ok [1, 'foo', 1.2],
+  {
+  definitions => {my_false_ref => false},
+  type        => 'array',
+  items       => {'$ref' => '#/definitions/my_false_ref'},
+  },
+  E('/0', 'Should not match.'), E('/1', 'Should not match.'),
+  E('/2', 'Should not match.');
+
+validate_ok [1, 'foo', 1.2],
+  {
+  definitions => {my_true_ref => true, my_false_ref => false},
+  type        => 'array',
+  items       => [
+    {'$ref' => '#/definitions/my_true_ref'},
+    {'$ref' => '#/definitions/my_true_ref'},
+    {'$ref' => '#/definitions/my_false_ref'}
+  ],
+  },
+  E('/2', 'Should not match.');
+
 done_testing;

--- a/t/jv-basic.t
+++ b/t/jv-basic.t
@@ -7,4 +7,14 @@ validate_ok j($_), {type => 'any'} for undef, [], {}, 123, 'foo';
 validate_ok j(undef), {type => 'null'};
 validate_ok j(1), {type => 'null'}, E('/', 'Not null.');
 
+validate_ok($_, {})
+  foreach (true, false, 1, 1.2, 'a string', {a => 'b'}, [1, 2, 3]);
+
+# TODO! true, false are draft 6+ only
+validate_ok($_, true)
+  foreach (true, false, 1, 1.2, 'a string', {a => 'b'}, [1, 2, 3]);
+
+validate_ok($_, false, E('/', 'Should not match.'))
+  foreach (true, false, 1, 1.2, 'a string', {a => 'b'}, [1, 2, 3]);
+
 done_testing;

--- a/t/jv-const.t
+++ b/t/jv-const.t
@@ -84,4 +84,10 @@ validate_ok [1, 'a', undef], $array_constant;
 validate_ok [1, 'b', undef], $array_constant,
   E('/', q{Does not match const: [1,"a",null].});
 
+validate_ok true,  {const => true};
+validate_ok false, {const => false};
+
+validate_ok false, {const => true},  E('/', 'Does not match const: true.');
+validate_ok true,  {const => false}, E('/', 'Does not match const: false.');
+
 done_testing;

--- a/t/jv-object.t
+++ b/t/jv-object.t
@@ -136,4 +136,51 @@ validate_ok {a => 1}, $object_constant;
 validate_ok {b => 1}, $object_constant,
   E('/', q{Does not match const: {"a":1}.});
 
+
+validate_ok {foo => 'bar'}, {type => 'object', required => ['foo'], %$_}
+  foreach { properties => {foo => {}} }
+, {additionalProperties => {}}, {patternProperties => {foo => {}}};
+
+validate_ok {foo => 'bar'},
+  {
+  definitions => {my_true_ref => {}},
+  type        => 'object',
+  required    => ['foo'],
+  %$_
+  } foreach { properties => {foo => {'$ref' => '#/definitions/my_true_ref'}} }
+, {additionalProperties => {'$ref' => '#/definitions/my_true_ref'}},
+  {patternProperties => {foo => {'$ref' => '#/definitions/my_true_ref'}}};
+
+# TODO! true, false are draft 6+ only
+validate_ok {foo => 'bar'}, {type => 'object', required => ['foo'], %$_}
+  foreach { properties => {foo => true} }
+, {additionalProperties => true}, {patternProperties => {foo => true}};
+
+validate_ok {foo => 'bar'},
+  {
+  definitions => {my_true_ref => true},
+  type        => 'object',
+  required    => ['foo'],
+  %$_
+  } foreach { properties => {foo => {'$ref' => '#/definitions/my_true_ref'}} }
+, {additionalProperties => {'$ref' => '#/definitions/my_true_ref'}},
+  {patternProperties => {foo => {'$ref' => '#/definitions/my_true_ref'}}};
+
+validate_ok {foo => 'bar'}, {type => 'object', required => ['foo'], %$_},
+  E('/foo', 'Should not match.')
+  foreach { properties => {foo => false} }
+, {patternProperties => {foo => false}};
+
+validate_ok {foo => 'bar'},
+  {
+  definitions => {my_false_ref => false},
+  type        => 'object',
+  required    => ['foo'],
+  %$_
+  },
+  E('/foo', 'Should not match.')
+  foreach { properties => {foo => {'$ref' => '#/definitions/my_false_ref'}} }
+, {additionalProperties => {'$ref' => '#/definitions/my_false_ref'}},
+  {patternProperties => {foo => {'$ref' => '#/definitions/my_false_ref'}}};
+
 done_testing;


### PR DESCRIPTION
### Summary
Now accepts (sub)schemas that are the boolean values `true` or `false`.

### Motivation
`true` and `false` are valid subschemas in draft 6 and later, as per https://json-schema.org/understanding-json-schema/basics.html