### PR TITLE
fix if-then-else, anyOf, dependencies

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -558,6 +558,14 @@ sub _validate {
       $self->_validate_one_of($to_json ? $$to_json : $_[1], $path, $rules);
   }
 
+  if ($schema->{if}) {
+    my $rules
+      = $self->_validate($data, $path, $schema->{if})
+      ? $schema->{else}
+      : $schema->{then};
+    push @errors, $self->_validate($data, $path, $rules // {});
+  }
+
   return @errors;
 }
 
@@ -853,12 +861,6 @@ sub _validate_type_object {
       next unless my @e = $self->_validate($name, $path, $n_schema);
       push @errors, prefix_errors propertyName => [map { ($name, $_) } @e];
     }
-  }
-  if ($schema->{if}) {
-    push @errors,
-      $self->_validate($data, $path, $schema->{if})
-      ? $self->_validate($data, $path, $schema->{else} // {})
-      : $self->_validate($data, $path, $schema->{then} // {});
   }
 
   my %rules;

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -549,11 +549,13 @@ sub _validate {
     push @errors,
       $self->_validate_all_of($to_json ? $$to_json : $_[1], $path, $rules);
   }
-  elsif ($rules = $schema->{anyOf}) {
+
+  if (my $rules = $schema->{anyOf}) {
     push @errors,
       $self->_validate_any_of($to_json ? $$to_json : $_[1], $path, $rules);
   }
-  elsif ($rules = $schema->{oneOf}) {
+
+  if (my $rules = $schema->{oneOf}) {
     push @errors,
       $self->_validate_one_of($to_json ? $$to_json : $_[1], $path, $rules);
   }

--- a/lib/JSON/Validator/Error.pm
+++ b/lib/JSON/Validator/Error.pm
@@ -35,6 +35,7 @@ our $MESSAGES = {
     maxProperties        => 'Too many properties: %3/%4.',
     minProperties        => 'Not enough properties: %3/%4.',
     required             => 'Missing property.',
+    dependencies         => 'Missing property. Dependee: %3.',
   },
   oneOf => {
     all_rules_match => 'All of the oneOf rules match.',

--- a/lib/JSON/Validator/Util.pm
+++ b/lib/JSON/Validator/Util.pm
@@ -123,7 +123,6 @@ sub schema_type {
   return _guessed_right(object => $_[1]) if $_[0]->{properties};
   return _guessed_right(object => $_[1]) if $_[0]->{propertyNames};
   return _guessed_right(object => $_[1]) if $_[0]->{required};
-  return _guessed_right(object => $_[1]) if $_[0]->{if};
   return _guessed_right(object => $_[1])
     if defined $_[0]->{maxProperties}
     or defined $_[0]->{minProperties};

--- a/t/jv-allof.t
+++ b/t/jv-allof.t
@@ -17,4 +17,26 @@ validate_ok 'superlong', $schema, E('/', '/allOf/0 String is too long: 9/7.'),
   E('/', '/allOf/1 String is too long: 9/5.');
 validate_ok 'toolong', $schema, E('/', '/allOf/1 String is too long: 7/5.');
 
+
+$schema = {
+  allOf =>
+    [{type => 'string', maxLength => 5}, {type => 'string', minLength => 3}],
+  anyOf => [{pattern => '^[0-9]+$'}, {pattern => '^[a-z]+$'}],
+  oneOf => [{pattern => '^[0-9]+$'}, {pattern => '^[a-z]+$', maxLength => 4}],
+};
+
+validate_ok '123',   $schema;
+validate_ok 'aaaa',  $schema;
+validate_ok 'aaaaa', $schema,
+  E('/', '/oneOf/0 String does not match ^[0-9]+$.'),
+  E('/', '/oneOf/1 String is too long: 5/4.');
+
+validate_ok 'he110th3re', $schema,
+  E('/', '/allOf/0 String is too long: 10/5.'),
+  E('/', '/anyOf/0 String does not match ^[0-9]+$.'),
+  E('/', '/anyOf/1 String does not match ^[a-z]+$.'),
+  E('/', '/oneOf/0 String does not match ^[0-9]+$.'),
+  E('/', '/oneOf/1 String is too long: 10/4.'),
+  E('/', '/oneOf/1 String does not match ^[a-z]+$.');
+
 done_testing;

--- a/t/jv-if-then-else.t
+++ b/t/jv-if-then-else.t
@@ -1,0 +1,30 @@
+use lib '.';
+use t::Helper;
+
+my $schema;
+
+$schema = {
+  if   => {properties => {ifx => {type      => 'string'}}},
+  then => {properties => {ifx => {maxLength => 3}}},
+  else => {properties => {ifx => {type      => 'number'}}},
+};
+
+validate_ok {ifx => 'foo'},    $schema;
+validate_ok {ifx => 'foobar'}, $schema, E('/ifx', 'String is too long: 6/3.');
+validate_ok {ifx => 42},       $schema;
+validate_ok {ifx => []}, $schema, E('/ifx', 'Expected number - got array.');
+
+$schema = {
+  type => 'array',
+  if   => {maxItems => 5},
+  then => {items => {pattern => '^[0-9]$'}},
+  else => {items => {pattern => '^[a-z]$'}},
+};
+
+validate_ok [qw(2 4 7)], $schema;
+validate_ok [qw(a 1)], $schema, E('/0', 'String does not match ^[0-9]$.');
+validate_ok [qw(6 q a b 8 z)], $schema,
+  E('/0', 'String does not match ^[a-z]$.'),
+  E('/4', 'String does not match ^[a-z]$.');
+
+done_testing;

--- a/t/jv-object.t
+++ b/t/jv-object.t
@@ -113,19 +113,6 @@ my $schema;
   validate_ok {name => 'John', surname => 'Doe'}, $schema;
 }
 
-{
-  my $schema = {
-    if   => {properties => {ifx => {type      => 'string'}}},
-    then => {properties => {ifx => {maxLength => 3}}},
-    else => {properties => {ifx => {type      => 'number'}}},
-  };
-
-  validate_ok {ifx => 'foo'},    $schema;
-  validate_ok {ifx => 'foobar'}, $schema, E('/ifx', 'String is too long: 6/3.');
-  validate_ok {ifx => 42},       $schema;
-  validate_ok {ifx => []}, $schema, E('/ifx', 'Expected number - got array.');
-}
-
 sub TO_JSON { return {age => shift->{age}} }
 my $obj = bless {age => 'not_a_string'}, 'main';
 validate_ok $obj, {properties => {age => {type => 'integer'}}},

--- a/t/jv-object.t
+++ b/t/jv-object.t
@@ -82,7 +82,6 @@ my $schema;
 }
 
 {
-  local $TODO = 'Add support for dependencies';
   $schema = {
     type       => 'object',
     properties => {
@@ -94,8 +93,28 @@ my $schema;
     dependencies => {credit_card => ['billing_address']}
   };
 
+  validate_ok {name => 'John Doe'}, $schema;
+  validate_ok {name => 'John Doe', billing_address => '123 Main St'}, $schema;
   validate_ok {name => 'John Doe', credit_card => 5555555555555555}, $schema,
-    E('/credit_card', 'Missing billing_address.', 'credit_card');
+    E('/billing_address', 'Missing property. Dependee: credit_card.');
+
+  $schema = {
+    type => 'object',
+    properties =>
+      {name => {type => 'string'}, credit_card => {type => 'number'}},
+    required     => ['name'],
+    dependencies => {
+      credit_card => {
+        properties => {billing_address => {type => 'string'}},
+        required   => ['billing_address'],
+      },
+    },
+  };
+
+  validate_ok {name => 'John Doe'}, $schema;
+  validate_ok {name => 'John Doe', billing_address => '123 Main St'}, $schema;
+  validate_ok {name => 'John Doe', credit_card => 5555555555555555}, $schema,
+    E('/billing_address', 'Missing property.');
 }
 
 {


### PR DESCRIPTION
### Summary
fixes bugs: #190, #196, #192 where various keywords were not fully supported

### Motivation
see their respective issues for background and references

I am not quite sure what error messages are best: "Missing property" was already being used by the 'required' keyword, and it's not great to have two different errors sharing the same message, so I made the 'required' error "Missing required property", so 'dependencies' can have "Missing dependent property". However, changing an existing error message might break unit tests in downstream code.