### PR TITLE
fix: handle validation of true, false schemas in oneOf

### DIFF
--- a/lib/JSON/Validator/Util.pm
+++ b/lib/JSON/Validator/Util.pm
@@ -118,6 +118,7 @@ sub prefix_errors {
 }
 
 sub schema_type {
+  return '' if ref $_[0] ne 'HASH';
   return $_[0]->{type} if $_[0]->{type};
   return _guessed_right(object => $_[1]) if $_[0]->{additionalProperties};
   return _guessed_right(object => $_[1]) if $_[0]->{patternProperties};

--- a/t/jv-oneof.t
+++ b/t/jv-oneof.t
@@ -39,4 +39,12 @@ validate_ok {x => undef}, $schema;
 validate_ok 1, {oneOf => [{minimum => 1}, {minimum => 2}, {maximum => 3}]},
   E('/', 'oneOf rules 0, 2 match.');
 
+validate_ok 'hello', {oneOf => [true, false]};
+
+validate_ok 'hello', {oneOf => [true, true]},
+  E('/', 'All of the oneOf rules match.');
+
+validate_ok 'hello', {oneOf => [false, false]},
+  E('/', '/oneOf/0 Should not match.'), E('/', '/oneOf/1 Should not match.');
+
 done_testing;


### PR DESCRIPTION
### Summary
`schema_type` did not handle boolean schemas.
