### PR TITLE
Optimize checksum generation for simple cases

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,7 @@ my %WriteMakefileArgs = (
     },
   },
   PREREQ_PM     => {'List::Util' => '1.45', 'Mojolicious' => '7.28'},
-  TEST_REQUIRES => {'Test::More' => '1.30', 'Test::Deep'  => '0'},
+  TEST_REQUIRES => {'Test::More' => '1.30', 'Test::Deep'  => '0', 'Test::Without::Module' => '0.20'},
   test => {TESTS => (-e 'META.yml' ? 't/*.t' : 't/*.t xt/*.t')},
 );
 

--- a/lib/JSON/Validator/Util.pm
+++ b/lib/JSON/Validator/Util.pm
@@ -2,7 +2,6 @@ package JSON::Validator::Util;
 use Mojo::Base -strict;
 
 use Carp         ();
-use Data::Dumper ();
 use Exporter 'import';
 use JSON::Validator::Error;
 use List::Util;
@@ -18,7 +17,11 @@ our @EXPORT_OK
 sub E { JSON::Validator::Error->new(@_) }
 
 sub data_checksum {
-  Mojo::Util::md5_sum(Data::Dumper->new([@_])->Sortkeys(1)->Useqq(1)->Dump);
+  return Mojo::Util::md5_sum(
+    ref $_[0]
+    ? Mojo::JSON::encode_json([@_])
+    : defined $_[0] ? qq('$_[0]')
+    :                 'undef');
 }
 
 sub data_section {
@@ -118,7 +121,7 @@ sub prefix_errors {
 }
 
 sub schema_type {
-  return '' if ref $_[0] ne 'HASH';
+  return ''            if ref $_[0] ne 'HASH';
   return $_[0]->{type} if $_[0]->{type};
   return _guessed_right(object => $_[1]) if $_[0]->{additionalProperties};
   return _guessed_right(object => $_[1]) if $_[0]->{patternProperties};

--- a/t/util-checksum-yaml-xs.t
+++ b/t/util-checksum-yaml-xs.t
@@ -1,0 +1,29 @@
+use Test::Without::Module qw( Sereal::Encoder );
+
+use Mojo::Util 'md5_sum';
+use JSON::Validator;
+use JSON::Validator::Util qw(data_checksum);
+use Test::More;
+
+my $d_hash  = {foo => {}, bar => {}};
+my $d_hash2 = {bar => {}, foo => {}};
+my $d_undef = {foo => undef};
+my $d_obj   = {foo => JSON::Validator::Error->new};
+my $d_array  = ['foo', 'bar'];
+my $d_array2 = ['bar', 'foo'];
+
+use_ok 'YAML::XS';
+isnt data_checksum($d_array), data_checksum($d_array2), 'data_checksum array';
+is data_checksum($d_hash), data_checksum($d_hash2),
+  'data_checksum hash field order';
+isnt data_checksum($d_hash), data_checksum($d_undef),
+  'data_checksum hash not undef';
+isnt data_checksum($d_hash), data_checksum($d_obj),
+  'data_checksum hash not object';
+isnt data_checksum($d_obj), data_checksum($d_undef),
+  'data_checksum object not undef';
+isnt data_checksum(3.14), md5_sum(3.15), 'data_checksum numeric';
+is data_checksum(3.14), data_checksum('3.14'),
+  'data_checksum numeric like string';
+
+done_testing;

--- a/t/util.t
+++ b/t/util.t
@@ -1,8 +1,9 @@
 use Mojo::Base -strict;
 use Mojo::JSON 'false';
+use Mojo::Util 'md5_sum';
 use JSON::Validator;
 use JSON::Validator::Util
-  qw(E data_type schema_type prefix_errors is_type json_pointer);
+  qw(E data_checksum data_type schema_type prefix_errors is_type json_pointer);
 use Test::More;
 
 my $e = E '/path/x', 'some error';
@@ -51,5 +52,24 @@ is schema_type({minLength => 4}), 'string', 'schema_type string';
 is schema_type({multipleOf => 2}),       'number', 'schema_type number';
 is schema_type({const      => 42}),      'const',  'schema_type const';
 is schema_type({cannot     => 'guess'}), '',       'schema_type no idea';
+
+my $d_hash  = {foo => {}, bar => {}};
+my $d_hash2 = {bar => {}, foo => {}};
+my $d_undef = {foo => undef};
+my $d_obj   = {foo => JSON::Validator::Error->new};
+my $d_array  = ('foo', 'bar');
+my $d_array2 = ('bar', 'foo');
+isnt data_checksum($d_array), data_checksum($d_array2), 'data_checksum array';
+is data_checksum($d_hash), data_checksum($d_hash2),
+  'data_checksum hash field order';
+isnt data_checksum($d_hash), data_checksum($d_undef),
+  'data_checksum hash not undef';
+isnt data_checksum($d_hash), data_checksum($d_obj),
+  'data_checksum hash not object';
+isnt data_checksum($d_obj), data_checksum($d_undef),
+  'data_checksum object not undef';
+isnt data_checksum(3.14), md5_sum(3.15), 'data_checksum numeric';
+is data_checksum(3.14), data_checksum('3.14'),
+  'data_checksum numeric like string';
 
 done_testing;

--- a/t/util.t
+++ b/t/util.t
@@ -53,23 +53,29 @@ is schema_type({multipleOf => 2}),       'number', 'schema_type number';
 is schema_type({const      => 42}),      'const',  'schema_type const';
 is schema_type({cannot     => 'guess'}), '',       'schema_type no idea';
 
-my $d_hash  = {foo => {}, bar => {}};
-my $d_hash2 = {bar => {}, foo => {}};
-my $d_undef = {foo => undef};
-my $d_obj   = {foo => JSON::Validator::Error->new};
-my $d_array  = ('foo', 'bar');
-my $d_array2 = ('bar', 'foo');
-isnt data_checksum($d_array), data_checksum($d_array2), 'data_checksum array';
-is data_checksum($d_hash), data_checksum($d_hash2),
-  'data_checksum hash field order';
-isnt data_checksum($d_hash), data_checksum($d_undef),
-  'data_checksum hash not undef';
-isnt data_checksum($d_hash), data_checksum($d_obj),
-  'data_checksum hash not object';
-isnt data_checksum($d_obj), data_checksum($d_undef),
-  'data_checksum object not undef';
-isnt data_checksum(3.14), md5_sum(3.15), 'data_checksum numeric';
-is data_checksum(3.14), data_checksum('3.14'),
-  'data_checksum numeric like string';
+subtest 'data_checksum with Sereal::Encoder' => sub {
+  plan skip_all => 'Sereal::Encoder not installed'
+    unless eval 'use Sereal::Encoder;1';
+
+  my $d_hash  = {foo => {}, bar => {}};
+  my $d_hash2 = {bar => {}, foo => {}};
+  my $d_undef = {foo => undef};
+  my $d_obj   = {foo => JSON::Validator::Error->new};
+  my $d_array  = ['foo', 'bar'];
+  my $d_array2 = ['bar', 'foo'];
+
+  isnt data_checksum($d_array), data_checksum($d_array2), 'data_checksum array';
+  is data_checksum($d_hash), data_checksum($d_hash2),
+    'data_checksum hash field order';
+  isnt data_checksum($d_hash), data_checksum($d_undef),
+    'data_checksum hash not undef';
+  isnt data_checksum($d_hash), data_checksum($d_obj),
+    'data_checksum hash not object';
+  isnt data_checksum($d_obj), data_checksum($d_undef),
+    'data_checksum object not undef';
+  isnt data_checksum(3.14), md5_sum(3.15), 'data_checksum numeric';
+  is data_checksum(3.14), data_checksum('3.14'),
+    'data_checksum numeric like string';
+};
 
 done_testing;


### PR DESCRIPTION
### Summary
Calling Data::Dumper is relatively slow, so avoiding it when easily possible can provide a significant performance improvement.

All the tests pass, and I've also run them several times with code that chooses the new path randomly only 50% of time. I've also verified that all the cases encountered in the tests and validation of the real schema (see below), the new code and Data::Dumper create equals keys.

### Motivation
Avoiding Data::Dumper for undef, string and numeric variables makes the validation about 40 percent faster for my test case of loading and validating Koha's REST API schema.

### References
My test script: https://gist.github.com/EreMaijala/5ba3ae6e3739c948f774a8a1246ca879
My test results: https://gist.github.com/EreMaijala/163b135c280be694e615c2be4e3ac2f7
Koha's REST API schema: https://github.com/Koha-Community/Koha/blob/master/api/v1/swagger/swagger.json