### PR TITLE
fix edge cases from PR#201 where error types are misidentified

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,7 +31,7 @@ my %WriteMakefileArgs = (
     },
   },
   PREREQ_PM     => {'List::Util' => '1.45', 'Mojolicious' => '7.28'},
-  TEST_REQUIRES => {'Test::More' => '1.30', 'Test::Deep'  => '0'},
+  TEST_REQUIRES => {'Test::More' => '1.30', 'Test::Deep'  => '0', 'Test::Without::Module' => '0.20'},
   test => {TESTS => (-e 'META.yml' ? 't/*.t' : 't/*.t xt/*.t')},
 );
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -586,13 +586,15 @@ sub _validate_all_of {
 
   return if not @errors;
 
+  my @details = map { my ($i, @e) = @$_; map $_->details, @e } @errors;
+
   return prefix_errors(allOf => @errors)
-    if @errors == 1
-    or grep $_->[1]->details->[1] ne 'type', @errors;
+    if @details == 1
+    or grep $_->[1] ne 'type', @details;
 
   # combine all 'type' errors together
-  my $want_types = join('/', uniq map $_->[1]->details->[0], @errors);
-  return E $path, [allOf => type => $want_types, $errors[-1][1]->details->[2]];
+  my $want_types = join '/', uniq map $_->[0], @details;
+  return E $path, [allOf => type => $want_types, $details[-1][2]];
 }
 
 sub _validate_any_of_types {
@@ -610,8 +612,9 @@ sub _validate_any_of_types {
   }
 
   # combine all 'type' errors together
-  my $want_types = join('/', uniq map $_->details->[0], @errors);
-  return E $path, [$want_types => 'type', $errors[-1]->details->[2]];
+  my @details    = map $_->details, @errors;
+  my $want_types = join '/', uniq map $_->[0], @details;
+  return E $path, [$want_types => 'type', $details[-1][2]];
 }
 
 sub _validate_any_of {
@@ -627,12 +630,15 @@ sub _validate_any_of {
     $i++;
   }
 
+  my @details = map { my ($i, @e) = @$_; map $_->details, @e } @errors;
+
   return prefix_errors(anyOf => @errors)
-    if grep $_->[1]->details->[1] ne 'type', @errors;
+    if @details == 1
+    or grep $_->[1] ne 'type', @details;
 
   # combine all 'type' errors together
-  my $want_types = join('/', uniq map $_->[1]->details->[0], @errors);
-  return E $path, [anyOf => type => $want_types, $errors[-1][1]->details->[2]];
+  my $want_types = join '/', uniq map $_->[0], @details;
+  return E $path, [anyOf => type => $want_types, $details[-1][2]];
 }
 
 sub _validate_one_of {
@@ -652,12 +658,15 @@ sub _validate_one_of {
   return E $path, [oneOf => 'all_rules_match'] unless @errors;
   return E $path, [oneOf => 'n_rules_match', join(', ', @passed)] if @passed;
 
+  my @details = map { my ($i, @e) = @$_; map $_->details, @e } @errors;
+
   return prefix_errors(oneOf => @errors)
-    if grep $_->[1]->details->[1] ne 'type', @errors;
+    if @details == 1
+    or grep $_->[1] ne 'type', @details;
 
   # combine all 'type' errors together
-  my $want_types = join('/', uniq map $_->[1]->details->[0], @errors);
-  return E $path, [oneOf => type => $want_types, $errors[-1][1]->details->[2]];
+  my $want_types = join '/', uniq map $_->[0], @details;
+  return E $path, [oneOf => type => $want_types, $details[-1][2]];
 }
 
 sub _validate_number_max {

--- a/lib/JSON/Validator/Util.pm
+++ b/lib/JSON/Validator/Util.pm
@@ -2,7 +2,6 @@ package JSON::Validator::Util;
 use Mojo::Base -strict;
 
 use Carp         ();
-use Data::Dumper ();
 use Exporter 'import';
 use JSON::Validator::Error;
 use List::Util;
@@ -18,7 +17,11 @@ our @EXPORT_OK
 sub E { JSON::Validator::Error->new(@_) }
 
 sub data_checksum {
-  Mojo::Util::md5_sum(Data::Dumper->new([@_])->Sortkeys(1)->Useqq(1)->Dump);
+  return Mojo::Util::md5_sum(
+    ref $_[0]
+    ? Mojo::JSON::encode_json([@_])
+    : defined $_[0] ? qq('$_[0]')
+    :                 'undef');
 }
 
 sub data_section {
@@ -118,7 +121,7 @@ sub prefix_errors {
 }
 
 sub schema_type {
-  return '' if ref $_[0] ne 'HASH';
+  return ''            if ref $_[0] ne 'HASH';
   return $_[0]->{type} if $_[0]->{type};
   return _guessed_right(object => $_[1]) if $_[0]->{additionalProperties};
   return _guessed_right(object => $_[1]) if $_[0]->{patternProperties};

--- a/lib/JSON/Validator/Util.pm
+++ b/lib/JSON/Validator/Util.pm
@@ -114,7 +114,7 @@ sub prefix_errors {
     push @errors, map {
       my $msg = sprintf '/%s/%s %s', $type, $index, $_->message;
       $msg =~ s!(\d+)\s/!$1/!g;
-      E $_->path, $msg;
+      E +{%$_, message => $msg};   # preserve 'details', for later introspection
     } @$e;
   }
 

--- a/t/jv-allof.t
+++ b/t/jv-allof.t
@@ -42,7 +42,18 @@ validate_ok 'he110th3re', $schema,
 validate_ok 'hello', {type => ['integer', 'boolean']},
   E('/', 'Expected integer/boolean - got string.');
 
-validate_ok 'hello', {allOf => [true, {type => ['integer', 'boolean']}]},
-  E('/', '/allOf/1 Expected integer/boolean - got string.');
+validate_ok 'hello', {allOf => [{type => ['integer', 'boolean']}]},
+  E('/', '/allOf/0 Expected integer/boolean - got string.');
+
+validate_ok 'hello',
+  {
+  allOf => [
+    {allOf => [{type => 'boolean'}, {type => 'string', maxLength => 2}]},
+    {type  => 'integer'},
+  ],
+  },
+  E('/', '/allOf/0/allOf/0 Expected boolean - got string.'),
+  E('/', '/allOf/0/allOf/1 String is too long: 5/2.'),
+  E('/', '/allOf/1 Expected integer - got string.');
 
 done_testing;

--- a/t/jv-allof.t
+++ b/t/jv-allof.t
@@ -56,4 +56,14 @@ validate_ok 'hello',
   E('/', '/allOf/0/allOf/1 String is too long: 5/2.'),
   E('/', '/allOf/1 Expected integer - got string.');
 
+validate_ok {foo => 'not an arrayref'},
+  {
+  allOf => [
+    {type => 'object', properties => {foo => {type => 'array'}}},
+    {type => 'boolean'},
+  ]
+  },
+  E('/foo', '/allOf/0 Expected array - got string.'),
+  E('/',    '/allOf/1 Expected boolean - got object.');
+
 done_testing;

--- a/t/jv-anyof.t
+++ b/t/jv-anyof.t
@@ -77,4 +77,18 @@ validate_ok 'hello', {anyOf => [false, {type => ['integer', 'boolean']}]},
 validate_ok 'hello', {type => ['integer', 'boolean']},
   E('/', 'Expected integer/boolean - got string.');
 
+validate_ok 'hello', {anyOf => [{type => ['integer', 'boolean']}]},
+  E('/', '/anyOf/0 Expected integer/boolean - got string.');
+
+validate_ok 'hello',
+  {
+  anyOf => [
+    {anyOf => [{type => 'boolean'}, {type => 'string', maxLength => 2}]},
+    {type  => 'integer'},
+  ],
+  },
+  E('/', '/anyOf/0/anyOf/0 Expected boolean - got string.'),
+  E('/', '/anyOf/0/anyOf/1 String is too long: 5/2.'),
+  E('/', '/anyOf/1 Expected integer - got string.');
+
 done_testing;

--- a/t/jv-anyof.t
+++ b/t/jv-anyof.t
@@ -91,4 +91,18 @@ validate_ok 'hello',
   E('/', '/anyOf/0/anyOf/1 String is too long: 5/2.'),
   E('/', '/anyOf/1 Expected integer - got string.');
 
+validate_ok {foo => 'not an arrayref'},
+  {type => ['object', 'boolean'], properties => {foo => {type => 'array'}}},
+  E('/foo', 'Expected array - got string.');
+
+validate_ok {foo => 'not an arrayref'},
+  {
+  anyOf => [
+    {type => 'object', properties => {foo => {type => 'array'}}},
+    {type => 'boolean'},
+  ]
+  },
+  E('/foo', '/anyOf/0 Expected array - got string.'),
+  E('/',    '/anyOf/1 Expected boolean - got object.');
+
 done_testing;

--- a/t/jv-oneof.t
+++ b/t/jv-oneof.t
@@ -68,4 +68,18 @@ validate_ok 'hello', {oneOf => [false, {type => 'integer'}]},
   E('/', '/oneOf/0 Should not match.'),
   E('/', '/oneOf/1 Expected integer - got string.');
 
+validate_ok 'hello', {oneOf => [{type => ['integer', 'boolean']}]},
+  E('/', '/oneOf/0 Expected integer/boolean - got string.');
+
+validate_ok 'hello',
+  {
+  oneOf => [
+    {oneOf => [{type => 'boolean'}, {type => 'string', maxLength => 2}]},
+    {type  => 'integer'},
+  ],
+  },
+  E('/', '/oneOf/0/oneOf/0 Expected boolean - got string.'),
+  E('/', '/oneOf/0/oneOf/1 String is too long: 5/2.'),
+  E('/', '/oneOf/1 Expected integer - got string.');
+
 done_testing;

--- a/t/jv-oneof.t
+++ b/t/jv-oneof.t
@@ -82,4 +82,14 @@ validate_ok 'hello',
   E('/', '/oneOf/0/oneOf/1 String is too long: 5/2.'),
   E('/', '/oneOf/1 Expected integer - got string.');
 
+validate_ok {foo => 'not an arrayref'},
+  {
+  oneOf => [
+    {type => 'object', properties => {foo => {type => 'array'}}},
+    {type => 'boolean'},
+  ]
+  },
+  E('/foo', '/oneOf/0 Expected array - got string.'),
+  E('/',    '/oneOf/1 Expected boolean - got object.');
+
 done_testing;

--- a/t/util-checksum-yaml-xs.t
+++ b/t/util-checksum-yaml-xs.t
@@ -1,0 +1,29 @@
+use Test::Without::Module qw( Sereal::Encoder );
+
+use Mojo::Util 'md5_sum';
+use JSON::Validator;
+use JSON::Validator::Util qw(data_checksum);
+use Test::More;
+
+my $d_hash  = {foo => {}, bar => {}};
+my $d_hash2 = {bar => {}, foo => {}};
+my $d_undef = {foo => undef};
+my $d_obj   = {foo => JSON::Validator::Error->new};
+my $d_array  = ['foo', 'bar'];
+my $d_array2 = ['bar', 'foo'];
+
+use_ok 'YAML::XS';
+isnt data_checksum($d_array), data_checksum($d_array2), 'data_checksum array';
+is data_checksum($d_hash), data_checksum($d_hash2),
+  'data_checksum hash field order';
+isnt data_checksum($d_hash), data_checksum($d_undef),
+  'data_checksum hash not undef';
+isnt data_checksum($d_hash), data_checksum($d_obj),
+  'data_checksum hash not object';
+isnt data_checksum($d_obj), data_checksum($d_undef),
+  'data_checksum object not undef';
+isnt data_checksum(3.14), md5_sum(3.15), 'data_checksum numeric';
+is data_checksum(3.14), data_checksum('3.14'),
+  'data_checksum numeric like string';
+
+done_testing;

--- a/t/util.t
+++ b/t/util.t
@@ -1,8 +1,9 @@
 use Mojo::Base -strict;
 use Mojo::JSON 'false';
+use Mojo::Util 'md5_sum';
 use JSON::Validator;
 use JSON::Validator::Util
-  qw(E data_type schema_type prefix_errors is_type json_pointer);
+  qw(E data_checksum data_type schema_type prefix_errors is_type json_pointer);
 use Test::More;
 
 my $e = E '/path/x', 'some error';
@@ -51,5 +52,24 @@ is schema_type({minLength => 4}), 'string', 'schema_type string';
 is schema_type({multipleOf => 2}),       'number', 'schema_type number';
 is schema_type({const      => 42}),      'const',  'schema_type const';
 is schema_type({cannot     => 'guess'}), '',       'schema_type no idea';
+
+my $d_hash  = {foo => {}, bar => {}};
+my $d_hash2 = {bar => {}, foo => {}};
+my $d_undef = {foo => undef};
+my $d_obj   = {foo => JSON::Validator::Error->new};
+my $d_array  = ('foo', 'bar');
+my $d_array2 = ('bar', 'foo');
+isnt data_checksum($d_array), data_checksum($d_array2), 'data_checksum array';
+is data_checksum($d_hash), data_checksum($d_hash2),
+  'data_checksum hash field order';
+isnt data_checksum($d_hash), data_checksum($d_undef),
+  'data_checksum hash not undef';
+isnt data_checksum($d_hash), data_checksum($d_obj),
+  'data_checksum hash not object';
+isnt data_checksum($d_obj), data_checksum($d_undef),
+  'data_checksum object not undef';
+isnt data_checksum(3.14), md5_sum(3.15), 'data_checksum numeric';
+is data_checksum(3.14), data_checksum('3.14'),
+  'data_checksum numeric like string';
 
 done_testing;

--- a/t/util.t
+++ b/t/util.t
@@ -53,23 +53,29 @@ is schema_type({multipleOf => 2}),       'number', 'schema_type number';
 is schema_type({const      => 42}),      'const',  'schema_type const';
 is schema_type({cannot     => 'guess'}), '',       'schema_type no idea';
 
-my $d_hash  = {foo => {}, bar => {}};
-my $d_hash2 = {bar => {}, foo => {}};
-my $d_undef = {foo => undef};
-my $d_obj   = {foo => JSON::Validator::Error->new};
-my $d_array  = ('foo', 'bar');
-my $d_array2 = ('bar', 'foo');
-isnt data_checksum($d_array), data_checksum($d_array2), 'data_checksum array';
-is data_checksum($d_hash), data_checksum($d_hash2),
-  'data_checksum hash field order';
-isnt data_checksum($d_hash), data_checksum($d_undef),
-  'data_checksum hash not undef';
-isnt data_checksum($d_hash), data_checksum($d_obj),
-  'data_checksum hash not object';
-isnt data_checksum($d_obj), data_checksum($d_undef),
-  'data_checksum object not undef';
-isnt data_checksum(3.14), md5_sum(3.15), 'data_checksum numeric';
-is data_checksum(3.14), data_checksum('3.14'),
-  'data_checksum numeric like string';
+subtest 'data_checksum with Sereal::Encoder' => sub {
+  plan skip_all => 'Sereal::Encoder not installed'
+    unless eval 'use Sereal::Encoder;1';
+
+  my $d_hash  = {foo => {}, bar => {}};
+  my $d_hash2 = {bar => {}, foo => {}};
+  my $d_undef = {foo => undef};
+  my $d_obj   = {foo => JSON::Validator::Error->new};
+  my $d_array  = ['foo', 'bar'];
+  my $d_array2 = ['bar', 'foo'];
+
+  isnt data_checksum($d_array), data_checksum($d_array2), 'data_checksum array';
+  is data_checksum($d_hash), data_checksum($d_hash2),
+    'data_checksum hash field order';
+  isnt data_checksum($d_hash), data_checksum($d_undef),
+    'data_checksum hash not undef';
+  isnt data_checksum($d_hash), data_checksum($d_obj),
+    'data_checksum hash not object';
+  isnt data_checksum($d_obj), data_checksum($d_undef),
+    'data_checksum object not undef';
+  isnt data_checksum(3.14), md5_sum(3.15), 'data_checksum numeric';
+  is data_checksum(3.14), data_checksum('3.14'),
+    'data_checksum numeric like string';
+};
 
 done_testing;


### PR DESCRIPTION
### Summary
These new test cases expose cases where the `[ $i, @errors ]` structures have more than one error in them, and consequently the detection of 'type' errors was incorrect.  A change to JSON::Validator::Error was required to preserve the `details` field that we rely on here (`prefix_errors` was removing that field, resulting in the errors appearing to have `generic` type.)

### References
as discussed on irc from the last few days.
