### PR TITLE
Use YAML::PP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
   - "HARNESS_OPTIONS=j6 TEST_RANDOM_ITERATIONS=5000"
 install:
   - "cpanm -n Test::Pod Test::Pod::Coverage"
-  - "cpanm -n Data::Validate::Domain Data::Validate::IP Cpanel::JSON::XS Net::IDN::Encode YAML::XS"
+  - "cpanm -n Data::Validate::Domain Data::Validate::IP Cpanel::JSON::XS Net::IDN::Encode YAML::PP"
   - "cpanm -n --installdeps ."
 sudo: false
 notifications:

--- a/t/booleans.t
+++ b/t/booleans.t
@@ -21,8 +21,7 @@ validate_ok {v => '1'},     $schema, E('/v', 'Expected boolean - got string.');
 validate_ok {v => '0'},     $schema, E('/v', 'Expected boolean - got string.');
 validate_ok {v => ''},      $schema, E('/v', 'Expected boolean - got string.');
 
-SKIP: {
-  skip 'YAML::XS is not installed', 1 unless JSON::Validator->YAML_SUPPORT;
+{
   my $data = jv->_load_schema_from_text(\"---\nv: true\n");
   isa_ok($data->{v}, 'JSON::PP::Boolean');
   validate_ok $data, $schema;

--- a/t/load-yaml.t
+++ b/t/load-yaml.t
@@ -2,8 +2,6 @@ use Mojo::Base -strict;
 use JSON::Validator;
 use Test::More;
 
-plan skip_all => 'YAML::XS required' unless JSON::Validator->YAML_SUPPORT;
-
 my $jv     = JSON::Validator->new;
 my @errors = $jv->schema('data://Some::Module/s_pec-/-ficaTion')
   ->validate({firstName => 'yikes!'});

--- a/t/more-bundle.t
+++ b/t/more-bundle.t
@@ -3,9 +3,6 @@ use JSON::Validator;
 use Test::Deep;
 use Test::More;
 
-plan skip_all => 'YAML::XS is not installed'
-  unless JSON::Validator->YAML_SUPPORT;
-
 # these are triples:
 # - schema name to extract from schema file(s) with bundle()
 # - expected result


### PR DESCRIPTION
Note: This is a draft.

### Summary
Use YAML::PP instead of YAML::XS.
Make it a hard requirement (since it's pureperl).

### Motivation
YAML::PP supports YAML 1.2, while YAML::XS only supports a subset/mixture of YAML 1.1/1.2.
Also it's pureperl.

Because YAML::PP is much slower than YAML::XS, it might be useful to support both via an environment variable or option.

Also YAML::PP::LibYAML could be supported (a bit faster than YAML::PP, slower than YAML::XS, but supports YAML 1.2 (regarding loading integers/booleans etc.))

For reference about YAML 1.2 I made this table: https://perlpunk.github.io/YAML-PP-p5/schemas.html
Default is YAML 1.2 Core Schema.