### PR TITLE
Fix uri resolution

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -394,16 +394,18 @@ sub _register_schema {
 sub _resolve {
   my ($self, $schema) = @_;
   my $id_key = $self->_id_key;
-  my ($id, $resolved);
+  my $id;
 
   local $self->{level} = $self->{level} || 0;
   delete $_[0]->{schemas}{''} unless $self->{level};
 
   if (ref $schema eq 'HASH') {
     $id = $schema->{$id_key} // '';
-    return $resolved if $resolved = $self->{schemas}{$id};
+    if (my $resolved = $self->{schemas}{$id}) {
+      return $resolved;
+    }
   }
-  elsif ($resolved = $self->{schemas}{$schema // ''}) {
+  elsif (my $resolved = $self->{schemas}{$schema // ''}) {
     return $resolved;
   }
   elsif (is_type $schema, 'BOOL') {

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -454,6 +454,7 @@ sub _resolve {
         my $fqn = Mojo::URL->new($topic->{$id_key});
         $fqn = $fqn->to_abs($base) unless $fqn->is_abs;
         $self->_register_schema($topic, url_unescape $fqn);
+        $base = $fqn;
       }
 
       push @topics, map { [$_, $base] } values %$topic;

--- a/t/acceptance.t
+++ b/t/acceptance.t
@@ -17,10 +17,11 @@ $t->get_ok('/integer.json')->status_is(200);
 my $host_port = $t->ua->server->url->host_port;
 
 my $test_only_re = $ENV{TEST_ONLY} || '';
-my $todo_re      = join('|',
-  'change resolution scope - changed scope ref valid',
-  $ENV{TEST_ONLINE} ? () : ('remote ref'),
-);
+my $todo_re      = join(
+  '|',
+
+  # insert failing test descriptions here
+) || '^$';
 
 for my $file (sort $test_suite->list->each) {
   for my $group (@{decode_json($file->slurp)}) {

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -15,7 +15,7 @@ my $bundled;
   $jv->_load_schema_from_url("http://json-schema.org/draft-07/schema");
 }
 
-note 'Run multiple times to make sure _reset() works';
+note 'Run multiple times to make sure _resolve level works';
 for my $n (1 .. 3) {
   note "[$n] replace=1";
   $bundled = $jv->bundle({

--- a/t/load-data.t
+++ b/t/load-data.t
@@ -6,6 +6,9 @@ my $jv = JSON::Validator->new;
 my @errors
   = $jv->schema('data://main/spec.json')->validate({firstName => 'yikes!'});
 
+is $jv->{schemas}{'data://main/spec.json'}{title}, 'Example Schema',
+  'registered this schema for reuse';
+
 is int(@errors), 1, 'one error';
 is $errors[0]->path,    '/lastName',         'lastName';
 is $errors[0]->message, 'Missing property.', 'required';

--- a/t/load-file.t
+++ b/t/load-file.t
@@ -10,4 +10,7 @@ ok eval { $jv->schema("file://$spec") }, 'loaded from file://';
 isa_ok($jv->schema, 'Mojo::JSON::Pointer');
 is $jv->schema->get('/title'), 'Example Schema', 'got example schema';
 
+is $jv->{schemas}{$spec}{title}, 'Example Schema',
+  'registered this schema for reuse';
+
 done_testing;

--- a/t/load-from-app.t
+++ b/t/load-from-app.t
@@ -18,4 +18,14 @@ plan skip_all => $@ if $@ =~ /\sGET\s/i;
 is $@, '', 'loaded schema from app';
 is $jv->get('/properties/swagger/enum/0'), '2.0', 'loaded schema structure';
 
+is $jv->{schemas}{'/spec'}{title}, 'A JSON Schema for Swagger 2.0 API.',
+  'registered this schema for reuse';
+
+is $jv->{schemas}{'http://swagger.io/v2/schema.json'}{title},
+  'A JSON Schema for Swagger 2.0 API.',
+  'registered this referenced schema for reuse';
+
+is $jv->{schemas}{'http://json-schema.org/draft-04/schema'}{description},
+  'Core schema meta-schema', 'registered this referenced schema for reuse';
+
 done_testing;

--- a/t/load-http.t
+++ b/t/load-http.t
@@ -13,4 +13,11 @@ like $jv->schema->get('/title'), qr{swagger}i, 'got swagger spec';
 ok $jv->schema->get('/patternProperties/^x-/description'),
   'resolved vendorExtension $ref';
 
+is $jv->{schemas}{'http://swagger.io/v2/schema.json'}{title},
+  'A JSON Schema for Swagger 2.0 API.',
+  'registered this referenced schema for reuse';
+
+is $jv->{schemas}{'http://json-schema.org/draft-04/schema'}{description},
+  'Core schema meta-schema', 'registered this referenced schema for reuse';
+
 done_testing;

--- a/t/load-json.t
+++ b/t/load-json.t
@@ -7,6 +7,9 @@ my $file   = path(path(__FILE__)->dirname, 'spec', 'person.json');
 my $jv     = JSON::Validator->new->schema($file);
 my @errors = $jv->validate({firstName => 'yikes!'});
 
+is $jv->{schemas}{Mojo::File::path(qw(t spec person.json))->to_abs}{title},
+  'Example Schema', 'registered this schema for reuse';
+
 is int(@errors), 1, 'one error';
 is $errors[0]->path,    '/lastName',         'lastName';
 is $errors[0]->message, 'Missing property.', 'required';
@@ -21,11 +24,23 @@ ok eval { JSON::Validator->new->schema("$file.2") },
   or diag $@;
 unlink "$file.2";
 
-# load from cache
+# we must load from cache, or we would die
 is(
-  eval { JSON::Validator->new->schema('http://swagger.io/v2/schema.json'); 42 },
+  eval {
+    $jv
+      = JSON::Validator->new(ua => undef)
+      ->schema('http://swagger.io/v2/schema.json');
+    42;
+  },
   42,
   'loaded from cache'
 ) or diag $@;
+
+is $jv->{schemas}{'http://swagger.io/v2/schema.json'}{title},
+  'A JSON Schema for Swagger 2.0 API.',
+  'registered this referenced schema for reuse';
+
+is $jv->{schemas}{'http://json-schema.org/draft-04/schema'}{description},
+  'Core schema meta-schema', 'registered this referenced schema for reuse';
 
 done_testing;

--- a/t/more-bundle.t
+++ b/t/more-bundle.t
@@ -202,7 +202,7 @@ my @tests = (
   ],
 );
 
-my $draft7_validator = JSON::Validator->new;
+my $draft7_validator = JSON::Validator->new->version(7);
 $draft7_validator->schema('http://json-schema.org/draft-07/schema#');
 
 my $bundler_validator = JSON::Validator->new;

--- a/t/resolve-against-uri.t
+++ b/t/resolve-against-uri.t
@@ -1,0 +1,42 @@
+use Mojo::Base -base;
+use lib '.';
+use t::Helper;
+
+my $schema1 = {
+  '$schema'  => 'http://json-schema.org/draft-07/schema#',
+  '$id'      => 'http://127.0.0.1:50754/json_schema/refs/self with spaces/1',
+  type       => 'object',
+  properties => {
+    a           => {type  => 'string', minLength => 4},
+    b           => {allOf => [{minLength => 3}, {'$ref' => '#/properties/a'},]},
+    'space age' => {type  => 'number'},
+  },
+};
+
+my $schema2 = {
+  '$schema'  => 'http://json-schema.org/draft-07/schema#',
+  '$id'      => 'http://127.0.0.1:50754/json_schema/refs/other/1',
+  type       => 'object',
+  properties => {
+    a => {
+      allOf => [
+        {minLength => 3},
+        {'$ref'    => '/json_schema/refs/self with spaces/1#/properties/a'},
+        {
+          '$ref' => '/json_schema/refs/self with spaces/1#/properties/space age'
+        },
+      ]
+    },
+  },
+};
+
+jv()->version(7);
+
+validate_ok {a => 'hi'}, $schema1, E('/a', 'String is too short: 2/4.');
+
+validate_ok {a => 'hi'}, $schema2,
+  E('/a', '/allOf/0 String is too short: 2/3.'),
+  E('/a', '/allOf/1 String is too short: 2/4.'),
+  E('/a', '/allOf/2 Expected number - got string.');
+
+done_testing;

--- a/t/resolve-against-uri.t
+++ b/t/resolve-against-uri.t
@@ -25,8 +25,12 @@ my $schema2 = {
         {
           '$ref' => '/json_schema/refs/self with spaces/1#/properties/space age'
         },
+        {'$ref' => 'new_base#'},    # this resolves to our document
       ]
     },
+
+    # to_abs = http://127.0.0.1:50754/json_schema/refs/other/new_base
+    new_base => {'$id' => 'new_base', type => 'boolean',},
   },
 };
 
@@ -37,6 +41,7 @@ validate_ok {a => 'hi'}, $schema1, E('/a', 'String is too short: 2/4.');
 validate_ok {a => 'hi'}, $schema2,
   E('/a', '/allOf/0 String is too short: 2/3.'),
   E('/a', '/allOf/1 String is too short: 2/4.'),
-  E('/a', '/allOf/2 Expected number - got string.');
+  E('/a', '/allOf/2 Expected number - got string.'),
+  E('/a', '/allOf/3 Expected boolean - got string.');
 
 done_testing;

--- a/t/spec/more-bundle.yaml
+++ b/t/spec/more-bundle.yaml
@@ -4,7 +4,7 @@ definitions:
   ref1:
     type: array
     items:
-      $ref: /definitions/ref2
+      $ref: "#/definitions/ref2"
   ref2:
     type: string
     minLength: 1
@@ -16,9 +16,9 @@ definitions:
     type: object
     properties:
       my_key1:
-        $ref: /definitions/ref1
+        $ref: "#/definitions/ref1"
       my_key2:
-        $ref: /definitions/ref1
+        $ref: "#/definitions/ref1"
   # actually a person, as in https://json-schema.org/understanding-json-schema/structuring.html
   i_have_a_recursive_ref:
     type: object
@@ -28,7 +28,7 @@ definitions:
       children:
         type: array
         items:
-          $ref: /definitions/i_have_a_recursive_ref
+          $ref: "#/definitions/i_have_a_recursive_ref"
         default: []
   i_have_a_ref_to_another_file:
     type: object
@@ -38,13 +38,13 @@ definitions:
       address:
         $ref: more-bundle2.yaml#/definitions/my_address
       secrets:
-        $ref: /definitions/ref1
+        $ref: "#/definitions/ref1"
   i_am_a_ref:
-    $ref: /definitions/ref1
+    $ref: "#/definitions/ref1"
   i_am_a_ref_level_1:
-    $ref: /definitions/i_am_a_ref_level_2
+    $ref: "#/definitions/i_am_a_ref_level_2"
   i_am_a_ref_level_2:
-    $ref: /definitions/ref3
+    $ref: "#/definitions/ref3"
   i_am_a_ref_to_another_file:
     $ref: more-bundle2.yaml#/definitions/i_have_a_ref_to_the_first_filename
   i_am_a_ref_with_the_same_name:
@@ -53,12 +53,12 @@ definitions:
     type: object
     properties:
       me:
-        $ref: /definitions/i_am_a_ref_with_the_same_name
+        $ref: "#/definitions/i_am_a_ref_with_the_same_name"
   i_contain_refs_to_same_named_definitions:
     type: object
     properties:
       foo:
-        $ref: /definitions/dupe_name
+        $ref: "#/definitions/dupe_name"
       bar:
         $ref: more-bundle2.yaml#/definitions/dupe_name
   i_have_a_ref_with_the_same_name:

--- a/t/spec/more-bundle2.yaml
+++ b/t/spec/more-bundle2.yaml
@@ -11,7 +11,7 @@ definitions:
         type: string
       city:
         # this is a local ref in a secondary file - resolution is extra tricky
-        $ref: /definitions/my_name
+        $ref: "#/definitions/my_name"
   dupe_name:
     type: string
   i_am_a_ref_with_the_same_name:


### PR DESCRIPTION
### Summary
There are various cases where uri resolution was not performed correctly with respect to `$id` and `$ref` keywords.
Many test cases have been added demonstrating things that did not work previously.

### Motivation
My application that uses JSON::Validator needs to pre-load and use documents with `$ref`s like `/foo/bar/baz#/json/pointer` and resolve them against `$id`s like `http://spec.app.corp.com`.

### References
URI resolution within document traversal is specified at https://tools.ietf.org/html/draft-handrews-json-schema-01#section-8.

Thank you Joyent for sponsoring the approximately 3 days of paid work that went into producing and verifying this pull request.
