### PR TITLE
Change JSON::Validator::schema() to hold a JSON::Validator::Schema object

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,8 @@ Revision history for perl distribution JSON-Validator
  - Deprecated JSON::Validator::version()
  - Removed JSON::Validator::generate_definitions_path()
  - Removed support for JSON::Validator::bundle({ref_key => ...})
+ - JSON::Validator::schema() now holds a JSON::Validator::Schema object
+   instead of Mojo::JSON::Pointer
 
 3.25 2020-03-26T07:42:16+0900
  - Made "additionalProperties" error message less confusing

--- a/lib/JSON/Validator/Schema.pm
+++ b/lib/JSON/Validator/Schema.pm
@@ -1,0 +1,211 @@
+package JSON::Validator::Schema;
+use Mojo::Base 'JSON::Validator';  # TODO: Change this to "use Mojo::Base -base"
+
+use Carp 'carp';
+use JSON::Validator::Util qw(E is_type);
+use Mojo::JSON::Pointer;
+
+has errors => sub {
+  my $self = shift;
+  my $url  = $self->specification || 'http://json-schema.org/draft-04/schema#';
+  my $jv   = $self->new(%$self)->data($url);
+
+  return [$jv->validate($self->data)];
+};
+
+has id => sub {
+  my $data = shift->data;
+  is_type($data, 'HASH') ? $data->{'$id'} || $data->{id} || '' : '';
+};
+
+has specification => sub {
+  my $data = shift->data;
+  is_type($data, 'HASH') ? $data->{'$schema'} || $data->{schema} || '' : '';
+};
+
+sub bundle {
+  my $self   = shift;
+  my $params = shift || {};
+  return $self->new($self->SUPER::bundle({%$params, schema => $self}), %$self);
+}
+
+sub contains {
+  state $p = Mojo::JSON::Pointer->new;
+  return $p->data(shift->{data})->contains(@_);
+}
+
+sub data {
+  my $self = shift;
+  return $self->{data} //= {} unless @_;
+  $self->{data} = $self->_resolve(shift);
+  delete $self->{errors};
+  return $self;
+}
+
+sub get {
+  state $p = Mojo::JSON::Pointer->new;
+  return $p->data(shift->{data})->get(@_) if @_ == 2 and ref $_[1] ne 'ARRAY';
+  return JSON::Validator::Util::schema_extract(shift->data, @_);
+}
+
+sub new {
+  return shift->SUPER::new(@_) if @_ % 2;
+
+  my ($class, $data) = (shift, shift);
+  return $class->SUPER::new(@_)->data($data);
+}
+
+sub validate {
+  my ($self, $data, $schema) = @_;
+  local $self->{schema}      = $self;  # back compat: set $jv->schema()
+  local $self->{seen}        = {};
+  local $self->{temp_schema} = [];     # make sure random-errors.t does not fail
+  return $self->_validate($_[1], '', $schema || $self->data);
+}
+
+# Should not be called on JSON::Validator::Schema
+for my $method (qw(load_and_validate_schema schema singleton version)) {
+  my $super = "JSON::Validator::$method";
+  Mojo::Util::monkey_patch(__PACKAGE__,
+    $method => sub {
+      my $class = ref $_[0];
+      carp "$class\::$method(...) is unsupported and will be removed.";
+      shift->$super(@_);
+    }
+  );
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+JSON::Validator::Schema - Base class for JSON::Validator schemas
+
+=head1 SYNOPSIS
+
+  package JSON::Validator::Schema::SomeSchema;
+  use Mojo::Base "JSON::Validator::Schema";
+  has specification => "https://api.example.com/my/spec.json#";
+  1;
+
+=head1 DESCRIPTION
+
+L<JSON::Validator::Schema> is currently EXPERIMENTAL, and most probably will
+change over the next versions as
+L<https://github.com/mojolicious/json-validator/pull/189> (or a competing PR)
+evolves.
+
+=head1 ATTRIBUTES
+
+=head2 errors
+
+  my $array_ref = $schema->errors;
+
+Holds the errors after checking L</data> against L</specification>.
+C<$array_ref> containing no elements means L</data> is valid. Each element in
+the array-ref is a L<JSON::Validator::Error> object.
+
+This attribute is I<not> changed by L</validate>. It only reflects if the
+C<$schema> is valid.
+
+=head2 id
+
+  my $str    = $schema->id;
+  my $schema = $schema->id($str);
+
+Holds the ID for this schema. Usually extracted from C<"$id"> or C<"id"> in
+L</data>.
+
+=head2 specification
+
+  my $str    = $schema->specification;
+  my $schema = $schema->specification($str);
+
+The URL to the specification used when checking for L</errors>. Usually
+extracted from C<"$schema"> or C<"schema"> in L</data>.
+
+=head1 METHODS
+
+=head2 bundle
+
+  my $bundled = $schema->bundle;
+
+C<$bundled> is a new L<JSON::Validator::Schema> object where none of the "$ref"
+will point to external resources. This can be useful, if you want to have a
+bunch of files locally, but hand over a single file to a client.
+
+  Mojo::File->new("client.json")
+    ->spurt(Mojo::JSON::to_json($schema->bundle->data));
+
+=head2 coerce
+
+  my $schema   = $schema->coerce("booleans,defaults,numbers,strings");
+  my $schema   = $schema->coerce({booleans => 1});
+  my $hash_ref = $schema->coerce;
+
+Set the given type to coerce. Before enabling coercion this module is very
+strict when it comes to validating types. Example: The string C<"1"> is not
+the same as the number C<1>. Note that it will also change the internal
+data-structure of the validated data: Example:
+
+  $schema->coerce({numbers => 1});
+  $schema->data({properties => {age => {type => "integer"}}});
+
+  my $input = {age => "42"};
+  $schema->validate($input);
+  # $input->{age} is now an integer 42 and not the string "42"
+
+=head2 contains
+
+See L<Mojo::JSON::Pointer/contains>.
+
+=head2 data
+
+  my $hash_ref = $schema->data;
+  my $schema   = $schema->data($bool);
+  my $schema   = $schema->data($hash_ref);
+  my $schema   = $schema->data($url);
+
+Will set a structure representing the schema. If the input is an C<$url> on
+contains "$ref" pointing to an URL, then these schemas will be downloaded and
+resolved.
+
+=head2 get
+
+  my $data = $schema->get($json_pointer);
+  my $data = $schema->get($json_pointer, sub { my ($data, $json_pointer) = @_; });
+
+Called with one argument, this method acts like L<Mojo::JSON::Pointer/get>,
+while if called with two arguments it will work like
+L<JSON::Validator::Util/schema_extract> instead:
+
+  JSON::Validator::Util::schema_extract($schema->data, sub { ... });
+
+The second argument can be C<undef()>, if you don't care about the callback.
+
+See L<Mojo::JSON::Pointer/get>.
+
+=head2 new
+
+  my $schema = JSON::Validator::Schema->new($data);
+  my $schema = JSON::Validator::Schema->new($data, %attributes);
+  my $schema = JSON::Validator::Schema->new(%attributes);
+
+Construct a new L<JSON::Validator::Schema> object. Passing on C<$data> will
+cause L</data> to be called, meaning the constructor might throw an exception
+if the schema could not be found.
+
+=head2 validate
+
+  my @errors = $schema->validate($any);
+
+Will validate C<$any> against the schema defined in L</data>. Each element in
+C<@errors> is a L<JSON::Validator::Error> object.
+
+=head1 SEE ALSO
+
+L<JSON::Validator>.
+
+=cut

--- a/t/get.t
+++ b/t/get.t
@@ -11,6 +11,10 @@ my $jv = JSON::Validator->new->schema({
 is $jv->get('/bar/2/z'), 'zzz', 'get /bar/2/z';
 is $jv->get([qw(nope 404)]), undef, 'get /nope/404';
 is_deeply $jv->get([qw(bar 0)]), {y => 'first'}, 'get /bar/0';
+is_deeply $jv->schema->get([qw(bar 0)], undef), {y => 'first'},
+  'schema->get /bar/0';
+is_deeply $jv->schema->get([qw(bar 0)]), {y => 'first'}, 'schema->get $ARRAY';
+ok $jv->schema->contains('/bar/0'), 'contains';
 
 # This is not officially supported. I think maybe the callback version is the way to go,
 # since it allows the JSON pointer to be passed on as well.
@@ -28,5 +32,10 @@ my @res;
 schema_extract($jv->schema->data, ['bar', undef, 'y'], sub { push @res, [@_] });
 is_deeply \@res, [['first', '/bar/0/y'], ['second', '/bar/1/y']],
   'schema_extract /bar/undef/y, $cb';
+
+@res = ();
+$jv  = $jv->schema->get(['bar', undef, 'y'], sub { push @res, [@_] });
+is_deeply \@res, [['first', '/bar/0/y'], ['second', '/bar/1/y']],
+  'schema->get /bar/undef/y, $cb';
 
 done_testing;

--- a/t/id-keyword-draft4.t
+++ b/t/id-keyword-draft4.t
@@ -24,6 +24,8 @@ eval { $jv->load_and_validate_schema("${base_url}relative-to-the-root.json") };
 ok !$@, "${base_url}relative-to-the-root.json" or diag $@;
 
 my $schema = $jv->schema;
+is $schema->specification, 'http://json-schema.org/draft-04/schema#',
+  'specification';
 is $schema->get('/id'), 'http://example.com/relative-to-the-root.json',
   'get /id';
 is $schema->get('/definitions/B/id'), 'b.json', 'id /definitions/B/id';

--- a/t/id-keyword-draft7.t
+++ b/t/id-keyword-draft7.t
@@ -20,7 +20,10 @@ eval {
 };
 ok !$@, "${base_url}schema.json" or diag $@;
 
-is $jv->version, 7,     'detected version from draft-07';
+is $jv->{version}, 7, 'detected version from draft-07';
+is $jv->schema->id, 'http://example.com/person.json', 'schema id';
+is $jv->schema->specification, 'http://json-schema.org/draft-07/schema#',
+  'schema specification';
 is $jv->_id_key, '$id', 'detected id_key from draft-07';
 
 eval { $jv->load_and_validate_schema("${base_url}invalid-relative.json") };

--- a/t/load-file.t
+++ b/t/load-file.t
@@ -7,7 +7,7 @@ my $jv   = JSON::Validator->new;
 
 note "file://$spec";
 ok eval { $jv->schema("file://$spec") }, 'loaded from file://';
-isa_ok($jv->schema, 'Mojo::JSON::Pointer');
+isa_ok($jv->schema, 'JSON::Validator::Schema');
 is $jv->schema->get('/title'), 'Example Schema', 'got example schema';
 
 done_testing;


### PR DESCRIPTION
### Summary
This PR is to make #189 smaller and easier to read. This PR is also back compatible with other modules such as JSON::Validator::OpenAPI::Mojolicious.

### Motivation
I think it's necessarily to split the functionality of JSON::Validator into separate schema classes to reduce the cost of maintaining the code for the new JSON-Schema drafts (and OpenAPI specifications. This PR is just the first step in that direction. Right now, we are getting more and more if/else branches such as `if ($jv->version == 6)` to run the correct logic for a given schema. I think creating a new JSON::Validator::Schema sub class will make it easier to read and understand the code.

The next step, without considering #189, would be to allow all the schema objects to be part of a shared pool, so if J::V creates a couple of schema objects, then they should be able to reference each other. I think this is pretty much done internally with `$self->{schemas}`, but it needs to be exposed in a nice way to the user.

### References
#189 
