### PR TITLE
Add schema classes for Draft4, Draft6 and Draft7

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -26,8 +26,11 @@ use constant YAML_SUPPORT      => eval 'use YAML::XS 0.67;1';
 our $VERSION   = '3.25';
 our @EXPORT_OK = qw(joi validate_json);
 
-# TODO
-our %SCHEMAS = ();
+our %SCHEMAS = (
+  'http://json-schema.org/draft-04/schema#' => '+Draft4',
+  'http://json-schema.org/draft-06/schema#' => '+Draft6',
+  'http://json-schema.org/draft-07/schema#' => '+Draft7',
+);
 
 my $BUNDLED_CACHE_DIR = path(path(__FILE__)->dirname, qw(Validator cache));
 my $HTTP_SCHEME_RE    = qr{^https?:};

--- a/lib/JSON/Validator/Error.pm
+++ b/lib/JSON/Validator/Error.pm
@@ -8,7 +8,9 @@ our $MESSAGES = {
   anyOf => {type => '/anyOf Expected %3 - got %4.'},
   array => {
     additionalItems => 'Invalid number of items: %3/%4.',
+    maxContains     => 'Contains too many items: %3/%4.',
     maxItems        => 'Too many items: %3/%4.',
+    minContains     => 'Contains not enough items: %3/%4.',
     minItems        => 'Not enough items: %3/%4.',
     uniqueItems     => 'Unique items required.',
     contains        => 'No items contained.',

--- a/lib/JSON/Validator/Schema.pm
+++ b/lib/JSON/Validator/Schema.pm
@@ -18,6 +18,12 @@ has id => sub {
   is_type($data, 'HASH') ? $data->{'$id'} || $data->{id} || '' : '';
 };
 
+has moniker => sub {
+  my $self = shift;
+  return "draft$1" if $self->specification =~ m!draft-(\d+)!;
+  return '';
+};
+
 has specification => sub {
   my $data = shift->data;
   is_type($data, 'HASH') ? $data->{'$schema'} || $data->{schema} || '' : '';
@@ -122,6 +128,18 @@ C<$schema> is valid.
 
 Holds the ID for this schema. Usually extracted from C<"$id"> or C<"id"> in
 L</data>.
+
+=head2 moniker
+
+  $str    = $schema->moniker;
+  $schema = $self->moniker("some_name");
+
+Used to get/set the moniker for the given schema. Will be "draft04" if
+L</specification> points to a JSON Schema draft URL, and fallback to
+empty string if unable to guess a moniker name.
+
+This attribute will (probably) detect more monikers from a given
+L</specification> or C</id> in the future.
 
 =head2 specification
 

--- a/lib/JSON/Validator/Schema.pm
+++ b/lib/JSON/Validator/Schema.pm
@@ -32,7 +32,8 @@ has specification => sub {
 sub bundle {
   my $self   = shift;
   my $params = shift || {};
-  return $self->new($self->SUPER::bundle({%$params, schema => $self}), %$self);
+  return $self->new(%$self)
+    ->data($self->SUPER::bundle({%$params, schema => $self}));
 }
 
 sub contains {

--- a/lib/JSON/Validator/Schema.pm
+++ b/lib/JSON/Validator/Schema.pm
@@ -92,6 +92,11 @@ JSON::Validator::Schema - Base class for JSON::Validator schemas
 
 =head1 DESCRIPTION
 
+L<JSON::Validator::Schema> is the base class for
+L<JSON::Validator::Schema::Draft4>,
+L<JSON::Validator::Schema::Draft6> and
+L<JSON::Validator::Schema::Draft7>.
+
 L<JSON::Validator::Schema> is currently EXPERIMENTAL, and most probably will
 change over the next versions as
 L<https://github.com/mojolicious/json-validator/pull/189> (or a competing PR)

--- a/lib/JSON/Validator/Schema/Draft4.pm
+++ b/lib/JSON/Validator/Schema/Draft4.pm
@@ -1,0 +1,57 @@
+package JSON::Validator::Schema::Draft4;
+use Mojo::Base 'JSON::Validator::Schema';
+
+use JSON::Validator::Util 'is_type';
+
+has id => sub {
+  my $data = shift->data;
+  return is_type($data, 'HASH') ? $data->{id} || '' : '';
+};
+
+has specification => 'http://json-schema.org/draft-04/schema#';
+
+sub _build_formats {
+  return {
+    'date-time' => JSON::Validator::Formats->can('check_date_time'),
+    'email'     => JSON::Validator::Formats->can('check_email'),
+    'hostname'  => JSON::Validator::Formats->can('check_hostname'),
+    'ipv4'      => JSON::Validator::Formats->can('check_ipv4'),
+    'ipv6'      => JSON::Validator::Formats->can('check_ipv6'),
+    'regex'     => JSON::Validator::Formats->can('check_regex'),
+    'uri'       => JSON::Validator::Formats->can('check_uri'),
+  };
+}
+
+sub _id_key {'id'}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+JSON::Validator::Schema::Draft4 - JSON-Schema Draft 4
+
+=head1 SYNOPSIS
+
+See L<JSON::Validator::Schema/SYNOPSIS>.
+
+=head1 DESCRIPTION
+
+This class represents
+L<https://json-schema.org/specification-links.html#draft-4>.
+
+=head1 ATTRIBUTES
+
+=head2 specification
+
+  my $str    = $schema->specification;
+  my $schema = $schema->specification($str);
+
+Defaults to "L<http://json-schema.org/draft-04/schema#>".
+
+=head1 SEE ALSO
+
+L<JSON::Validator::Schema>.
+
+=cut

--- a/lib/JSON/Validator/Schema/Draft4.pm
+++ b/lib/JSON/Validator/Schema/Draft4.pm
@@ -1,7 +1,8 @@
 package JSON::Validator::Schema::Draft4;
 use Mojo::Base 'JSON::Validator::Schema';
 
-use JSON::Validator::Util 'is_type';
+use JSON::Validator::Util qw(E data_checksum data_type is_type json_pointer);
+use List::Util 'uniq';
 
 has id => sub {
   my $data = shift->data;
@@ -22,7 +23,208 @@ sub _build_formats {
   };
 }
 
+sub _definitions_path_for_ref { ['definitions'] }
+
 sub _id_key {'id'}
+
+sub _validate_number_max {
+  my ($self, $value, $path, $schema, $expected) = @_;
+  return unless defined(my $cmp_with = $schema->{maximum});
+
+  my $key = $schema->{exclusiveMaximum} ? 'ex_maximum' : 'maximum';
+  return if $key eq 'maximum' ? $value <= $cmp_with : $value < $cmp_with;
+  return E $path, [$expected => $key => $value, $cmp_with];
+}
+
+sub _validate_number_min {
+  my ($self, $value, $path, $schema, $expected) = @_;
+  return unless defined(my $cmp_with = $schema->{minimum});
+
+  my $key = $schema->{exclusiveMinimum} ? 'ex_minimum' : 'minimum';
+  return if $key eq 'minimum' ? $value >= $cmp_with : $value > $cmp_with;
+  return E $path, [$expected => $key => $value, $cmp_with];
+}
+
+sub _validate_type_array {
+  my ($self, $data, $path, $schema) = @_;
+  return E $path, [array => type => data_type $data] if ref $data ne 'ARRAY';
+
+  return (
+    $self->_validate_type_array_min_max($_[1], $path, $schema),
+    $self->_validate_type_array_unique($_[1], $path, $schema),
+    $self->_validate_type_array_items($_[1], $path, $schema),
+  );
+}
+
+sub _validate_type_array_items {
+  my ($self, $data, $path, $schema) = @_;
+  my @errors;
+
+  if (ref $schema->{items} eq 'ARRAY') {
+    my $additional_items = $schema->{additionalItems} // {type => 'any'};
+    my @rules            = @{$schema->{items}};
+
+    if ($additional_items) {
+      push @rules, $additional_items while @rules < @$data;
+    }
+
+    if (@rules == @$data) {
+      for my $i (0 .. @rules - 1) {
+        push @errors, $self->_validate($data->[$i], "$path/$i", $rules[$i]);
+      }
+    }
+    elsif (!$additional_items) {
+      push @errors, E $path,
+        [array => additionalItems => int(@$data), int(@rules)];
+    }
+  }
+  elsif (exists $schema->{items}) {
+    for my $i (0 .. @$data - 1) {
+      push @errors, $self->_validate($data->[$i], "$path/$i", $schema->{items});
+    }
+  }
+
+  return @errors;
+}
+
+sub _validate_type_array_min_max {
+  my ($self, $data, $path, $schema) = @_;
+  my @errors;
+
+  if (defined $schema->{minItems} and $schema->{minItems} > @$data) {
+    push @errors, E $path,
+      [array => minItems => int(@$data), $schema->{minItems}];
+  }
+  if (defined $schema->{maxItems} and $schema->{maxItems} < @$data) {
+    push @errors, E $path,
+      [array => maxItems => int(@$data), $schema->{maxItems}];
+  }
+
+  return @errors;
+}
+
+sub _validate_type_array_unique {
+  my ($self, $data, $path, $schema) = @_;
+  return unless $schema->{uniqueItems};
+
+  my (@errors, %uniq);
+  for (@$data) {
+    next if !$uniq{data_checksum($_)}++;
+    push @errors, E $path, [array => 'uniqueItems'];
+    last;
+  }
+
+  return @errors;
+}
+
+sub _validate_type_object {
+  my ($self, $data, $path, $schema) = @_;
+  return E $path, [object => type => data_type $data] if ref $data ne 'HASH';
+
+  return (
+    $self->_validate_type_object_min_max($_[1], $path, $schema),
+    $self->_validate_type_object_dependencies($_[1], $path, $schema),
+    $self->_validate_type_object_properties($_[1], $path, $schema),
+  );
+}
+
+sub _validate_type_object_min_max {
+  my ($self, $data, $path, $schema) = @_;
+
+  my @errors;
+  my @dkeys = keys %$data;
+  if (defined $schema->{maxProperties} and $schema->{maxProperties} < @dkeys) {
+    push @errors, E $path,
+      [object => maxProperties => int(@dkeys), $schema->{maxProperties}];
+  }
+  if (defined $schema->{minProperties} and $schema->{minProperties} > @dkeys) {
+    push @errors, E $path,
+      [object => minProperties => int(@dkeys), $schema->{minProperties}];
+  }
+
+  return @errors;
+}
+
+sub _validate_type_object_dependencies {
+  my ($self, $data, $path, $schema) = @_;
+  my $dependencies = $schema->{dependencies} || {};
+  my @errors;
+
+  for my $k (keys %$dependencies) {
+    next if not exists $data->{$k};
+    if (ref $dependencies->{$k} eq 'ARRAY') {
+      push @errors,
+        map { E json_pointer($path, $_), [object => dependencies => $k] }
+        grep { !exists $data->{$_} } @{$dependencies->{$k}};
+    }
+    elsif (ref $dependencies->{$k} eq 'HASH') {
+      push @errors,
+        $self->_validate_type_object($data, $path, $schema->{dependencies}{$k});
+    }
+  }
+
+  return @errors;
+}
+
+sub _validate_type_object_properties {
+  my ($self, $data, $path, $schema) = @_;
+  my @dkeys = sort keys %$data;
+  my (@errors, %rules);
+
+  for my $k (keys %{$schema->{properties}}) {
+    my $r = $schema->{properties}{$k};
+    push @{$rules{$k}}, $r;
+    if (  $self->{coerce}{defaults}
+      and ref $r eq 'HASH'
+      and exists $r->{default}
+      and !exists $data->{$k})
+    {
+      $data->{$k} = $r->{default};
+    }
+  }
+
+  for my $p (keys %{$schema->{patternProperties} || {}}) {
+    my $r = $schema->{patternProperties}{$p};
+    push @{$rules{$_}}, $r for sort grep { $_ =~ /$p/ } @dkeys;
+  }
+
+  my $additional
+    = exists $schema->{additionalProperties}
+    ? $schema->{additionalProperties}
+    : {};
+  if ($additional) {
+    $additional = {} unless is_type $additional, 'HASH';
+    $rules{$_} ||= [$additional] for @dkeys;
+  }
+  elsif (my @k = grep { !$rules{$_} } @dkeys) {
+    local $" = ', ';
+    return E $path, [object => additionalProperties => join ', ', sort @k];
+  }
+
+  for my $k (sort { $a cmp $b } uniq @{$schema->{required} || []}) {
+    next if exists $data->{$k};
+    push @errors, E json_pointer($path, $k), [object => 'required'];
+    delete $rules{$k};
+  }
+
+  for my $k (sort keys %rules) {
+    for my $r (@{$rules{$k}}) {
+      next unless exists $data->{$k};
+      $r = $self->_ref_to_schema($r) if ref $r eq 'HASH' and $r->{'$ref'};
+      my @e = $self->_validate($data->{$k}, json_pointer($path, $k), $r);
+      push @errors, @e;
+      next if @e or !is_type $r, 'HASH';
+      push @errors,
+        $self->_validate_type_enum($data->{$k}, json_pointer($path, $k), $r)
+        if $r->{enum};
+      push @errors,
+        $self->_validate_type_const($data->{$k}, json_pointer($path, $k), $r)
+        if $r->{const};
+    }
+  }
+
+  return @errors;
+}
 
 1;
 

--- a/lib/JSON/Validator/Schema/Draft6.pm
+++ b/lib/JSON/Validator/Schema/Draft6.pm
@@ -1,0 +1,61 @@
+package JSON::Validator::Schema::Draft6;
+use Mojo::Base 'JSON::Validator::Schema::Draft4';
+
+use JSON::Validator::Util 'is_type';
+
+has id => sub {
+  my $data = shift->data;
+  return is_type($data, 'HASH') ? $data->{'$id'} || '' : '';
+};
+
+has specification => 'http://json-schema.org/draft-06/schema#';
+
+sub _build_formats {
+  return {
+    'date-time'    => JSON::Validator::Formats->can('check_date_time'),
+    'email'        => JSON::Validator::Formats->can('check_email'),
+    'hostname'     => JSON::Validator::Formats->can('check_hostname'),
+    'ipv4'         => JSON::Validator::Formats->can('check_ipv4'),
+    'ipv6'         => JSON::Validator::Formats->can('check_ipv6'),
+    'json-pointer' => JSON::Validator::Formats->can('check_json_pointer'),
+    'regex'        => JSON::Validator::Formats->can('check_regex'),
+    'relative-json-pointer' =>
+      JSON::Validator::Formats->can('check_relative_json_pointer'),
+    'uri'           => JSON::Validator::Formats->can('check_uri'),
+    'uri-reference' => JSON::Validator::Formats->can('check_uri_reference'),
+    'uri-template'  => JSON::Validator::Formats->can('check_uri_template'),
+  };
+}
+
+sub _id_key {'$id'}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+JSON::Validator::Schema::Draft6 - JSON-Schema Draft 6
+
+=head1 SYNOPSIS
+
+See L<JSON::Validator::Schema/SYNOPSIS>.
+
+=head1 DESCRIPTION
+
+This class represents
+L<https://json-schema.org/specification-links.html#draft-6>.
+
+=head1 ATTRIBUTES
+
+=head2 specification
+
+  my $str = $schema->specification;
+
+Defaults to "L<http://json-schema.org/draft-06/schema#>".
+
+=head1 SEE ALSO
+
+L<JSON::Validator::Schema>.
+
+=cut

--- a/lib/JSON/Validator/Schema/Draft6.pm
+++ b/lib/JSON/Validator/Schema/Draft6.pm
@@ -1,7 +1,7 @@
 package JSON::Validator::Schema::Draft6;
 use Mojo::Base 'JSON::Validator::Schema::Draft4';
 
-use JSON::Validator::Util 'is_type';
+use JSON::Validator::Util qw(E data_type is_type prefix_errors);
 
 has id => sub {
   my $data = shift->data;
@@ -28,6 +28,86 @@ sub _build_formats {
 }
 
 sub _id_key {'$id'}
+
+sub _validate_number_max {
+  my ($self, $value, $path, $schema, $expected) = @_;
+
+  my $cmp_with = $schema->{maximum};
+  return E $path, [$expected => maximum => $value, $cmp_with]
+    if defined $cmp_with and $value > $cmp_with;
+
+  $cmp_with = $schema->{exclusiveMaximum};
+  return E $path, [$expected => ex_maximum => $value, $cmp_with]
+    if defined $cmp_with and $value >= $cmp_with;
+
+  return;
+}
+
+sub _validate_number_min {
+  my ($self, $value, $path, $schema, $expected) = @_;
+
+  my $cmp_with = $schema->{minimum};
+  return E $path, [$expected => minimum => $value, $cmp_with]
+    if defined $cmp_with and $value < $cmp_with;
+
+  $cmp_with = $schema->{exclusiveMinimum};
+  return E $path, [$expected => ex_minimum => $value, $cmp_with]
+    if defined $cmp_with and $value <= $cmp_with;
+
+  return;
+}
+
+sub _validate_type_array {
+  my ($self, $data, $path, $schema) = @_;
+  return E $path, [array => type => data_type $data] if ref $data ne 'ARRAY';
+
+  return (
+    $self->_validate_type_array_min_max($_[1], $path, $schema),
+    $self->_validate_type_array_unique($_[1], $path, $schema),
+    $self->_validate_type_array_contains($_[1], $path, $schema),
+    $self->_validate_type_array_items($_[1], $path, $schema),
+  );
+}
+
+sub _validate_type_array_contains {
+  my ($self, $data, $path, $schema) = @_;
+  return unless $schema->{contains};
+
+  my (@e, @errors);
+  for my $i (0 .. @$data - 1) {
+    my @tmp = $self->_validate($data->[$i], "$path/$i", $schema->{contains});
+    push @e, \@tmp if @tmp;
+  }
+
+  push @errors, map {@$_} @e if @e >= @$data;
+  push @errors, E $path, [array => 'contains'] if not @$data;
+  return @errors;
+}
+
+sub _validate_type_object {
+  my ($self, $data, $path, $schema) = @_;
+  return E $path, [object => type => data_type $data] if ref $data ne 'HASH';
+
+  return (
+    $self->_validate_type_object_min_max($_[1], $path, $schema),
+    $self->_validate_type_object_names($_[1], $path, $schema),
+    $self->_validate_type_object_properties($_[1], $path, $schema),
+    $self->_validate_type_object_dependencies($_[1], $path, $schema),
+  );
+}
+
+sub _validate_type_object_names {
+  my ($self, $data, $path, $schema) = @_;
+  return unless my $names = $schema->{propertyNames};
+
+  my @errors;
+  for my $name (keys %$data) {
+    next unless my @e = $self->_validate($name, $path, $names);
+    push @errors, prefix_errors propertyName => map [$name, $_], @e;
+  }
+
+  return @errors;
+}
 
 1;
 

--- a/lib/JSON/Validator/Schema/Draft7.pm
+++ b/lib/JSON/Validator/Schema/Draft7.pm
@@ -1,0 +1,59 @@
+package JSON::Validator::Schema::Draft7;
+use Mojo::Base 'JSON::Validator::Schema::Draft6';
+
+has specification => 'http://json-schema.org/draft-07/schema#';
+
+sub _build_formats {
+  return {
+    'date'          => JSON::Validator::Formats->can('check_date'),
+    'date-time'     => JSON::Validator::Formats->can('check_date_time'),
+    'email'         => JSON::Validator::Formats->can('check_email'),
+    'hostname'      => JSON::Validator::Formats->can('check_hostname'),
+    'idn-email'     => JSON::Validator::Formats->can('check_idn_email'),
+    'idn-hostname'  => JSON::Validator::Formats->can('check_idn_hostname'),
+    'ipv4'          => JSON::Validator::Formats->can('check_ipv4'),
+    'ipv6'          => JSON::Validator::Formats->can('check_ipv6'),
+    'iri'           => JSON::Validator::Formats->can('check_iri'),
+    'iri-reference' => JSON::Validator::Formats->can('check_iri_reference'),
+    'json-pointer'  => JSON::Validator::Formats->can('check_json_pointer'),
+    'regex'         => JSON::Validator::Formats->can('check_regex'),
+    'relative-json-pointer' =>
+      JSON::Validator::Formats->can('check_relative_json_pointer'),
+    'time'          => JSON::Validator::Formats->can('check_time'),
+    'uri'           => JSON::Validator::Formats->can('check_uri'),
+    'uri-reference' => JSON::Validator::Formats->can('check_uri_reference'),
+    'uri-reference' => JSON::Validator::Formats->can('check_uri_reference'),
+    'uri-template'  => JSON::Validator::Formats->can('check_uri_template'),
+  };
+}
+
+1;
+
+=encoding utf8
+
+=head1 NAME
+
+JSON::Validator::Schema::Draft7 - JSON-Schema Draft 7
+
+=head1 SYNOPSIS
+
+See L<JSON::Validator::Schema/SYNOPSIS>.
+
+=head1 DESCRIPTION
+
+This class represents
+L<https://json-schema.org/specification-links.html#draft-7>.
+
+=head1 ATTRIBUTES
+
+=head2 specification
+
+  my $str = $schema->specification;
+
+Defaults to "L<http://json-schema.org/draft-07/schema#>".
+
+=head1 SEE ALSO
+
+L<JSON::Validator::Schema>.
+
+=cut

--- a/lib/JSON/Validator/Schema/Draft7.pm
+++ b/lib/JSON/Validator/Schema/Draft7.pm
@@ -7,6 +7,7 @@ sub _build_formats {
   return {
     'date'          => JSON::Validator::Formats->can('check_date'),
     'date-time'     => JSON::Validator::Formats->can('check_date_time'),
+    'duration'      => JSON::Validator::Formats->can('check_duration'),
     'email'         => JSON::Validator::Formats->can('check_email'),
     'hostname'      => JSON::Validator::Formats->can('check_hostname'),
     'idn-email'     => JSON::Validator::Formats->can('check_idn_email'),
@@ -23,6 +24,7 @@ sub _build_formats {
     'uri'           => JSON::Validator::Formats->can('check_uri'),
     'uri-reference' => JSON::Validator::Formats->can('check_uri_reference'),
     'uri-template'  => JSON::Validator::Formats->can('check_uri_template'),
+    'uuid'          => JSON::Validator::Formats->can('check_uuid'),
   };
 }
 

--- a/lib/JSON/Validator/Schema/Draft7.pm
+++ b/lib/JSON/Validator/Schema/Draft7.pm
@@ -22,10 +22,11 @@ sub _build_formats {
     'time'          => JSON::Validator::Formats->can('check_time'),
     'uri'           => JSON::Validator::Formats->can('check_uri'),
     'uri-reference' => JSON::Validator::Formats->can('check_uri_reference'),
-    'uri-reference' => JSON::Validator::Formats->can('check_uri_reference'),
     'uri-template'  => JSON::Validator::Formats->can('check_uri_template'),
   };
 }
+
+sub _definitions_path_for_ref { ['$defs'] }
 
 1;
 

--- a/lib/JSON/Validator/Util.pm
+++ b/lib/JSON/Validator/Util.pm
@@ -150,7 +150,9 @@ sub schema_type {
   return _guessed_right(number => $_[1]) if $_[0]->{multipleOf};
   return _guessed_right(number => $_[1])
     if defined $_[0]->{maximum}
-    or defined $_[0]->{minimum};
+    or defined $_[0]->{minimum}
+    or defined $_[0]->{exclusiveMaximum}
+    or defined $_[0]->{exclusiveMinimum};
   return 'const' if exists $_[0]->{const};
   return '';
 }

--- a/t/acceptance.t
+++ b/t/acceptance.t
@@ -1,5 +1,5 @@
 use Mojo::Base -strict;
-use JSON::Validator;
+use JSON::Validator::Schema::Draft4;
 use Mojo::File 'path';
 use Mojo::JSON qw(encode_json decode_json false true);
 use Test::Mojo;
@@ -22,6 +22,7 @@ my $todo_re      = join('|',
   $ENV{TEST_ONLINE} ? () : ('remote ref'),
 );
 
+my $jv = JSON::Validator->new->ua($t->ua);
 for my $file (sort $test_suite->list->each) {
   for my $group (@{decode_json($file->slurp)}) {
     for my $test (@{$group->{tests}}) {
@@ -38,11 +39,12 @@ expect_valid: @{[$test->{valid} ? 'Yes' : 'No']}
 HERE
 
       $schema =~ s!http\W+localhost:1234\b!http://$host_port!g;
-      $schema = decode_json $schema;
-
-      my @errors = eval {
-        JSON::Validator->new->ua($t->ua)->load_and_validate_schema($schema)
-          ->validate($test->{data});
+      my @errors;
+      eval {
+        $schema
+          = JSON::Validator::Schema::Draft4->new(decode_json($schema), %$jv);
+        @errors = @{$jv->schema($schema)->schema->errors};
+        @errors = $jv->validate($test->{data}) unless @errors;
       };
 
       my $e = $@ || join ', ', @errors;

--- a/t/bundle.t
+++ b/t/bundle.t
@@ -1,5 +1,6 @@
 use Mojo::Base -strict;
 use JSON::Validator;
+use JSON::Validator::Schema::Draft7;
 use Mojo::File 'path';
 use Test::More;
 
@@ -14,6 +15,13 @@ my $bundled;
   $jv->_load_schema_from_url("http://json-schema.org/draft-06/schema");
   $jv->_load_schema_from_url("http://json-schema.org/draft-07/schema");
 }
+
+my $schema = JSON::Validator::Schema::Draft7->new({
+  definitions => {name   => {type => 'string'}},
+  surname     => {'$ref' => '#/definitions/name'},
+});
+is $schema->bundle({replace => 1})->data->{surname}{type}, 'string',
+  "schema->bundle";
 
 note 'Run multiple times to make sure _reset() works';
 for my $n (1 .. 3) {
@@ -60,6 +68,7 @@ $bundled = $jv->schema('data://main/bundled.json')->bundle;
 is_deeply [sort keys %{$bundled->{definitions}}], ['objtype'],
   'no dup definitions';
 
+note 'definitions in disk spec';
 for my $path (
   ['test-definitions-key.json'],
   ['with-deep-mixed-ref.json'],
@@ -76,8 +85,8 @@ for my $path (
   $bundled = $jv->schema($file)->bundle;
   is_deeply [sort map { s!-[a-z0-9]{10}$!-SHA!; $_ }
       keys %{$bundled->{definitions}}], \@expected,
-    'right definitions in disk spec'
-    or diag explain $bundled->{definitions};
+    "right definitions in disk spec @$path"
+    or diag join ', ', sort keys %{$bundled->{definitions}};
 }
 
 note 'ensure filenames with funny characters not mangled by Mojo::URL';

--- a/t/draft4.t
+++ b/t/draft4.t
@@ -1,0 +1,34 @@
+use lib '.';
+use t::Helper;
+use JSON::Validator::Schema::Draft4;
+
+t::Helper->schema(JSON::Validator::Schema::Draft4->new);
+
+t::Helper->test(number => qw(basic maximum minimum));
+t::Helper->test(array  => qw(basic items additional_items min_max unique));
+t::Helper->test(object => qw(basic properties));
+t::Helper->test(object => qw(additional_properties pattern_properties min_max));
+
+note 'exclusiveMaximum';
+schema_validate_ok 2.4, {exclusiveMaximum => true, maximum => 2.4},
+  E('/', '2.4 >= maximum(2.4)');
+
+note 'exclusiveMinimum';
+schema_validate_ok 0, {exclusiveMaximum => true, maximum => 0},
+  E('/', '0 >= maximum(0)');
+
+note 'bundle';
+my $bundle
+  = JSON::Validator::Schema::Draft4->new->data('data://main/spec.json')->bundle;
+is $bundle->data->{properties}{name}{'$ref'}, '#/definitions/_name',
+  'bundle ref';
+is $bundle->data->{'definitions'}{_name}{type}, 'string',
+  'bundled spec under definitions';
+
+done_testing;
+
+__DATA__
+@@ spec.json
+{"type":"object","properties":{"name":{"$ref":"data://main/defs.json#/name"}}}
+@@ defs.json
+{"name":{"type":"string"}}

--- a/t/draft6.t
+++ b/t/draft6.t
@@ -1,0 +1,24 @@
+use lib '.';
+use t::Helper;
+use JSON::Validator::Schema::Draft6;
+
+t::Helper->schema(JSON::Validator::Schema::Draft6->new);
+
+t::Helper->test(number => qw(basic maximum minimum));
+t::Helper->test(
+  array => qw(basic items additional_items contains min_max unique));
+t::Helper->test(object => qw(basic properties));
+t::Helper->test(
+  object => qw(additional_properties pattern_properties min_max names));
+
+note 'exclusiveMaximum';
+schema_validate_ok 2.4, {exclusiveMaximum => 2.4},
+  E('/', '2.4 >= maximum(2.4)');
+schema_validate_ok 0, {exclusiveMaximum => 0}, E('/', '0 >= maximum(0)');
+
+note 'exclusiveMinimum';
+schema_validate_ok 4.2, {exclusiveMinimum => 4.2},
+  E('/', '4.2 <= minimum(4.2)');
+schema_validate_ok 0, {exclusiveMinimum => 0}, E('/', '0 <= minimum(0)');
+
+done_testing;

--- a/t/draft7.t
+++ b/t/draft7.t
@@ -30,6 +30,24 @@ my $bundle
 is $bundle->data->{properties}{name}{'$ref'}, '#/$defs/_name', 'bundle ref';
 is $bundle->data->{'$defs'}{_name}{type}, 'string', 'bundled spec under $defs';
 
+note 'formats';
+my $schema = {properties => {str => {type => 'string', format => 'duration'}}};
+schema_validate_ok {str => 'foo'}, $schema,
+  E('/str', 'Does not match duration format.');
+schema_validate_ok {str => 'P4Y'},              $schema;
+schema_validate_ok {str => 'PT0S'},             $schema;
+schema_validate_ok {str => 'P1M'},              $schema;
+schema_validate_ok {str => 'PT1M'},             $schema;
+schema_validate_ok {str => 'PT0.5M'},           $schema;
+schema_validate_ok {str => 'PT0,5M'},           $schema;
+schema_validate_ok {str => 'P23DT23H'},         $schema;
+schema_validate_ok {str => 'P3Y6M4DT12H30M5S'}, $schema;
+
+$schema->{properties}{str}{format} = 'uuid';
+schema_validate_ok {str => '5782165B-6BB6-A72F-B3DD-369D707D6C72'}, $schema,
+  E('/str', 'Does not match uuid format.');
+schema_validate_ok {str => '5782165B-6BB6-472F-B3DD-369D707D6C72'}, $schema;
+
 done_testing;
 
 __DATA__

--- a/t/draft7.t
+++ b/t/draft7.t
@@ -7,7 +7,7 @@ t::Helper->schema(JSON::Validator::Schema::Draft7->new);
 t::Helper->test(number => qw(basic maximum minimum));
 t::Helper->test(
   array => qw(basic items additional_items contains min_max unique));
-t::Helper->test(array  => qw(unevaluated_items));
+t::Helper->test(array  => qw(min_max_contains unevaluated_items));
 t::Helper->test(object => qw(basic properties));
 t::Helper->test(
   object => qw(additional_properties pattern_properties min_max names));

--- a/t/draft7.t
+++ b/t/draft7.t
@@ -1,0 +1,39 @@
+use lib '.';
+use t::Helper;
+use JSON::Validator::Schema::Draft7;
+
+t::Helper->schema(JSON::Validator::Schema::Draft7->new);
+
+t::Helper->test(number => qw(basic maximum minimum));
+t::Helper->test(
+  array => qw(basic items additional_items contains min_max unique));
+t::Helper->test(array  => qw(unevaluated_items));
+t::Helper->test(object => qw(basic properties));
+t::Helper->test(
+  object => qw(additional_properties pattern_properties min_max names));
+t::Helper->test(
+  object => qw(dependent_required dependent_schemas unevaluated_properties));
+
+note 'exclusiveMaximum';
+schema_validate_ok 2.4, {exclusiveMaximum => 2.4},
+  E('/', '2.4 >= maximum(2.4)');
+schema_validate_ok 0, {exclusiveMaximum => 0}, E('/', '0 >= maximum(0)');
+
+note 'exclusiveMinimum';
+schema_validate_ok 4.2, {exclusiveMinimum => 4.2},
+  E('/', '4.2 <= minimum(4.2)');
+schema_validate_ok 0, {exclusiveMinimum => 0}, E('/', '0 <= minimum(0)');
+
+note 'bundle';
+my $bundle
+  = JSON::Validator::Schema::Draft7->new->data('data://main/spec.json')->bundle;
+is $bundle->data->{properties}{name}{'$ref'}, '#/$defs/_name', 'bundle ref';
+is $bundle->data->{'$defs'}{_name}{type}, 'string', 'bundled spec under $defs';
+
+done_testing;
+
+__DATA__
+@@ spec.json
+{"type":"object","properties":{"name":{"$ref":"data://main/defs.json#/name"}}}
+@@ defs.json
+{"name":{"type":"string"}}

--- a/t/id-keyword-draft4.t
+++ b/t/id-keyword-draft4.t
@@ -24,6 +24,7 @@ eval { $jv->load_and_validate_schema("${base_url}relative-to-the-root.json") };
 ok !$@, "${base_url}relative-to-the-root.json" or diag $@;
 
 my $schema = $jv->schema;
+is $schema->moniker, 'draft04', 'moniker';
 is $schema->specification, 'http://json-schema.org/draft-04/schema#',
   'specification';
 is $schema->get('/id'), 'http://example.com/relative-to-the-root.json',

--- a/t/id-keyword-draft7.t
+++ b/t/id-keyword-draft7.t
@@ -21,7 +21,8 @@ eval {
 ok !$@, "${base_url}schema.json" or diag $@;
 
 is $jv->{version}, 7, 'detected version from draft-07';
-is $jv->schema->id, 'http://example.com/person.json', 'schema id';
+is $jv->schema->id,      'http://example.com/person.json', 'schema id';
+is $jv->schema->moniker, 'draft07',                        'moniker';
 is $jv->schema->specification, 'http://json-schema.org/draft-07/schema#',
   'schema specification';
 is $jv->_id_key, '$id', 'detected id_key from draft-07';

--- a/t/load-http.t
+++ b/t/load-http.t
@@ -8,7 +8,7 @@ my $jv = JSON::Validator->new;
 
 $jv->schema('http://swagger.io/v2/schema.json');
 
-isa_ok($jv->schema, 'Mojo::JSON::Pointer');
+isa_ok($jv->schema, 'JSON::Validator::Schema');
 like $jv->schema->get('/title'), qr{swagger}i, 'got swagger spec';
 ok $jv->schema->get('/patternProperties/^x-/description'),
   'resolved vendorExtension $ref';

--- a/t/test/array.pm
+++ b/t/test/array.pm
@@ -1,0 +1,72 @@
+package t::test::array;
+use t::Helper;
+
+sub additional_items {
+  my $schema = {
+    type            => 'array',
+    additionalItems => false,
+    items           => [
+      {type => 'number'},
+      {type => 'string'},
+      {type => 'string', enum => ['Street', 'Avenue', 'Boulevard']},
+      {type => 'string', enum => ['NW', 'NE', 'SW', 'SE']}
+    ]
+  };
+
+  validate_ok [1600, 'Pennsylvania', 'Avenue', 'NW', 'Washington'], $schema,
+    E('/', 'Invalid number of items: 5/4.');
+}
+
+sub basic {
+  my $schema = {type => 'array'};
+  schema_validate_ok [], $schema;
+  schema_validate_ok {}, $schema, E('/', 'Expected array - got object.');
+}
+
+sub contains {
+  my $schema
+    = {type => 'array', contains => {type => 'string', enum => ['NW']}};
+  schema_validate_ok [1600, 'NW'], $schema;
+
+  $schema->{contains}{enum} = ['Nope'];
+  schema_validate_ok [1600, 'NW'], $schema,
+    E('/0', 'Expected string - got number.'),
+    E('/1', 'Not in enum list: Nope.');
+}
+
+sub items {
+  my $schema = {type => 'array', items => {type => 'number'}};
+  validate_ok [1], $schema;
+  validate_ok [1, 'foo'], $schema, E('/1', 'Expected number - got string.');
+
+  $schema->{items} = {};
+  validate_ok [1, 'foo', 1.2], $schema;
+
+  $schema->{items} = true;
+  validate_ok [1, 'foo', 1.2], $schema;
+}
+
+sub min_max {
+  my $schema = {type => 'array', minItems => 2, maxItems => 2};
+
+  schema_validate_ok [1], $schema, E('/', 'Not enough items: 1/2.');
+  schema_validate_ok [1, 2], $schema;
+  schema_validate_ok [1, 2, 3], $schema, E('/', 'Too many items: 3/2.');
+}
+
+sub unevaluated_items {
+  local $TODO
+    = 'https://json-schema.org/draft/2019-09/json-schema-core.html#unevaluatedItems';
+  my $schema = {unevaluatedItems => {}};
+  validate_ok [1600, 'Pennsylvania', 'Avenue', 'NW', 'Washington'], $schema,
+    E('/', 'Invalid number of items: 5/4.');
+}
+
+sub unique {
+  my $schema
+    = {type => 'array', uniqueItems => 1, items => {type => 'integer'}};
+  validate_ok [123, 124], $schema;
+  validate_ok [1, 2, 1], $schema, E('/', 'Unique items required.');
+}
+
+1;

--- a/t/test/array.pm
+++ b/t/test/array.pm
@@ -54,6 +54,21 @@ sub min_max {
   schema_validate_ok [1, 2, 3], $schema, E('/', 'Too many items: 3/2.');
 }
 
+sub min_max_contains {
+  my $schema = {
+    type        => 'array',
+    contains    => {type => 'string'},
+    maxContains => 3,
+    minContains => 2,
+  };
+  schema_validate_ok [qw(A)], $schema,
+    E('/', 'Contains not enough items: 1/2.');
+  schema_validate_ok [qw(A B C D)], $schema,
+    E('/', 'Contains too many items: 4/3.');
+  schema_validate_ok [qw(A B)],   $schema;
+  schema_validate_ok [qw(A B C)], $schema;
+}
+
 sub unevaluated_items {
   local $TODO
     = 'https://json-schema.org/draft/2019-09/json-schema-core.html#unevaluatedItems';

--- a/t/test/number.pm
+++ b/t/test/number.pm
@@ -1,0 +1,20 @@
+package t::test::number;
+use t::Helper;
+
+sub basic {
+  schema_validate_ok 1, {type => 'number'};
+}
+
+sub maximum {
+  schema_validate_ok 0, {maximum => 0};
+  schema_validate_ok 1, {maximum => 1};
+  schema_validate_ok - 1, {maximum => -2}, E('/', '-1 > maximum(-2)');
+}
+
+sub minimum {
+  schema_validate_ok 0, {minimum => 0};
+  schema_validate_ok 1, {minimum => 1};
+  schema_validate_ok - 2, {minimum => -1}, E('/', '-2 < minimum(-1)');
+}
+
+1;

--- a/t/test/object.pm
+++ b/t/test/object.pm
@@ -1,0 +1,158 @@
+package t::test::object;
+use t::Helper;
+
+sub additional_properties {
+  my $schema = {
+    properties           => {number => {type => 'number'}},
+    additionalProperties => false
+  };
+
+  schema_validate_ok {direction => 'NW', foo => 'nope', number => 1600},
+    $schema, E('/', 'Properties not allowed: direction, foo.');
+
+  $schema->{additionalProperties} = {type => 'string'};
+  schema_validate_ok {number => 1600, foo => 'nope'}, $schema;
+}
+
+sub basic {
+  my $schema = {type => 'object'};
+  schema_validate_ok {mynumber => 1}, $schema;
+  schema_validate_ok [1], $schema, E('/', 'Expected object - got array.');
+}
+
+sub dependencies {
+  my $schema = {
+    dependencies => {credit_card => ['billing_address']},
+    properties   => {
+      name            => {type => 'string'},
+      credit_card     => {type => 'number'},
+      billing_address => {type => 'string'},
+    },
+  };
+
+  schema_validate_ok {name => 'John Doe'}, $schema;
+  schema_validate_ok {name => 'John Doe', billing_address => '123 Main St'},
+    $schema;
+  schema_validate_ok {name => 'John Doe', credit_card => 5555555555555555},
+    $schema, E('/billing_address', 'Missing property. Dependee: credit_card.');
+}
+
+sub dependent_required {
+  local $TODO
+    = 'https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.5.4';
+  my $schema = {
+    dependentRequired => {credit_card => ['billing_address']},
+    properties        => {
+      name            => {type => 'string'},
+      credit_card     => {type => 'number'},
+      billing_address => {type => 'string'},
+    },
+  };
+
+  schema_validate_ok {name => 'John Doe', credit_card => 5555555555555555},
+    $schema, E('/billing_address', 'Missing property. Dependee: credit_card.');
+}
+
+sub dependent_schemas {
+  local $TODO
+    = 'https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.2.2.4';
+
+  my $schema = {
+    dependentSchemas => {credit_card => ['billing_address']},
+    properties       => {
+      name            => {type => 'string'},
+      credit_card     => {type => 'number'},
+      billing_address => {type => 'string'},
+    },
+  };
+
+  schema_validate_ok {name => 'John Doe', credit_card => 5555555555555555},
+    $schema, E('/billing_address', 'Missing property. Dependee: credit_card.');
+}
+
+sub min_max {
+  my $schema = {minProperties => 2, maxProperties => 3};
+  schema_validate_ok {}, {minProperties => 1},
+    E('/', 'Not enough properties: 0/1.');
+  schema_validate_ok {a => 1}, $schema, E('/', 'Not enough properties: 1/2.');
+  schema_validate_ok {a => 1, b => 2}, $schema;
+  schema_validate_ok {a => 1, b => 2, c => 3}, $schema;
+  schema_validate_ok {a => 1, b => 2, c => 3, d => 4}, $schema,
+    E('/', 'Too many properties: 4/3.');
+}
+
+sub names {
+  my $schema = {propertyNames => {minLength => 3, maxLength => 5}};
+  schema_validate_ok {name => 'John', surname => 'Doe'}, $schema,
+    E('/', '/propertyName/surname String is too long: 7/5.');
+
+  $schema->{propertyNames}{maxLength} = 7;
+  schema_validate_ok {name => 'John', surname => 'Doe'}, $schema;
+
+  $schema = {
+    type          => 'object',
+    propertyNames => {
+      anyOf => [
+        {type => 'string', enum => ['foo', 'bar', 'baz']},
+        {type => 'string', enum => ['hello']},
+      ],
+    },
+  };
+
+  schema_validate_ok {FOO => 1}, $schema,
+    E('/', '/propertyName/FOO /anyOf/0 Not in enum list: foo, bar, baz.'),
+    E('/', '/propertyName/FOO /anyOf/1 Not in enum list: hello.');
+
+  schema_validate_ok {foo => 1}, $schema;
+}
+
+sub pattern_properties {
+  my $schema
+    = {patternProperties =>
+      {'^S_' => {type => 'string'}, '^I_' => {type => 'integer'}},
+    };
+
+  schema_validate_ok {'S_25' => 'This is a string', 'I_0' => 42}, $schema;
+  schema_validate_ok {'S_0' => 42}, $schema,
+    E('/S_0', 'Expected string - got number.');
+}
+
+sub properties {
+  my $schema = {
+    properties => {
+      number      => {type => 'number'},
+      street_name => {type => 'string'},
+      street_type =>
+        {type => 'string', enum => ['Street', 'Avenue', 'Boulevard']}
+    }
+  };
+
+  schema_validate_ok {number => 1600, street_name => 'Pennsylvania',
+    street_type => 'Avenue'}, $schema;
+  schema_validate_ok {number => '1600'}, $schema,
+    E('/number', 'Expected number - got string.');
+  schema_validate_ok {
+    number      => 1600,
+    street_name => 'Pennsylvania',
+    street_type => 'Avenue',
+    direction   => 'NW'
+  }, $schema;
+
+  $schema->{required} = ['number', 'street_name'];
+  validate_ok {number => 1600, street_type => 'Avenue'}, $schema,
+    E('/street_name', 'Missing property.');
+}
+
+sub unevaluated_properties {
+  local $TODO
+    = 'https://json-schema.org/draft/2019-09/json-schema-core.html#rfc.section.9.3.2.4';
+  my $schema = {
+    properties            => {number => {type => 'number'}},
+    unevaluatedProperties => false
+  };
+
+  schema_validate_ok {direction => 'NW', foo => 'nope', number => 1600},
+    $schema, E('/', 'Properties not allowed: direction, foo.');
+}
+
+1;


### PR DESCRIPTION
### Summary
This PR has sub classes for JSON-Schema draft-4, 6 and 7. I think there are more things that could be factored out from JSON::Validator, but maybe this is a good start?

### Motivation
See #209 for motivation.

### References
#209, #189.