### PR TITLE
demonstration: broken schema registration

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -370,6 +370,7 @@ sub _new_schema {
   my $schema = $self->_schema_class($spec)->new(
     $spec, @attrs,
     version => $self->{version},
+    schemas => ($self->{schemas} //= {}),
     map { ($_ => $self->$_) } qw(cache_paths formats ua)
   );
   $schema->specification($spec) if $spec and !$schema->specification;

--- a/t/load-data.t
+++ b/t/load-data.t
@@ -6,6 +6,9 @@ my $jv = JSON::Validator->new;
 my @errors
   = $jv->schema('data://main/spec.json')->validate({firstName => 'yikes!'});
 
+is $jv->{schemas}{'data://main/spec.json'}{title}, 'Example Schema',
+  'registered this schema for reuse';
+
 is int(@errors), 1, 'one error';
 is $errors[0]->path,    '/lastName',         'lastName';
 is $errors[0]->message, 'Missing property.', 'required';

--- a/t/load-file.t
+++ b/t/load-file.t
@@ -10,4 +10,7 @@ ok eval { $jv->schema("file://$spec") }, 'loaded from file://';
 isa_ok($jv->schema, 'JSON::Validator::Schema');
 is $jv->schema->get('/title'), 'Example Schema', 'got example schema';
 
+is $jv->{schemas}{$spec}{title}, 'Example Schema',
+  'registered this schema for reuse under the filename we loaded it from';
+
 done_testing;

--- a/t/load-from-app.t
+++ b/t/load-from-app.t
@@ -18,4 +18,14 @@ plan skip_all => $@ if $@ =~ /\sGET\s/i;
 is $@, '', 'loaded schema from app';
 is $jv->get('/properties/swagger/enum/0'), '2.0', 'loaded schema structure';
 
+is $jv->{schemas}{'/spec'}{title}, 'A JSON Schema for Swagger 2.0 API.',
+  'registered this schema for reuse';
+
+is $jv->{schemas}{'http://swagger.io/v2/schema.json'}{title},
+  'A JSON Schema for Swagger 2.0 API.',
+  'registered this referenced schema for reuse';
+
+is $jv->{schemas}{'http://json-schema.org/draft-04/schema'}{description},
+  'Core schema meta-schema', 'registered this referenced schema for reuse';
+
 done_testing;

--- a/t/load-http.t
+++ b/t/load-http.t
@@ -13,4 +13,11 @@ like $jv->schema->get('/title'), qr{swagger}i, 'got swagger spec';
 ok $jv->schema->get('/patternProperties/^x-/description'),
   'resolved vendorExtension $ref';
 
+is $jv->{schemas}{'http://swagger.io/v2/schema.json'}{title},
+  'A JSON Schema for Swagger 2.0 API.',
+  'registered this referenced schema for reuse';
+
+is $jv->{schemas}{'http://json-schema.org/draft-04/schema'}{description},
+  'Core schema meta-schema', 'registered this referenced schema for reuse';
+
 done_testing;


### PR DESCRIPTION
This demonstrates the problem with broken schema caching and resolution.

I fixed the simple problem of the registry being lost when ::Schema objects are changed (see its commit message), but because of the order in which the new Schema object is constructed, ref resolution ends in an infinite loop.