### PR TITLE
Fix the coercion of boolean value 'false'

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -893,7 +893,9 @@ sub _validate_type_boolean {
       or $value =~ /^(true|false)$/)
     )
   {
-    $_[1] = $value ? true : false;
+    $_[1] = $value eq 'true'  ? true
+          : $value eq 'false' ? false
+                              : ($value ? true : false);
     return;
   }
 

--- a/t/jv-boolean.t
+++ b/t/jv-boolean.t
@@ -30,13 +30,21 @@ validate_ok true, $bool_constant_true;
 validate_ok false, $bool_constant_true, E('/', q{Does not match const: true.});
 
 jv->coerce('bool');
-validate_ok {nick => 1000}, $schema;
-validate_ok {nick => 0.5},  $schema;
+validate_ok {nick => 1000},    $schema;
+validate_ok {nick => 0.5},     $schema;
+validate_ok {nick => 'true'},  $schema;
+validate_ok {nick => 'false'}, $schema;
 
-validate_ok 0,    $bool_constant_false;
-validate_ok 1000, $bool_constant_false, E('/', q{Does not match const: false.});
-validate_ok 1000, $bool_constant_true;
-validate_ok 0,    $bool_constant_true, E('/', q{Does not match const: true.});
+validate_ok 0,       $bool_constant_false;
+validate_ok 0,       $bool_constant_true, E('/', q{Does not match const: true.});
+validate_ok 0.5,     $bool_constant_false, E('/', q{Does not match const: false.});
+validate_ok 0.5,     $bool_constant_true;
+validate_ok 1000,    $bool_constant_false, E('/', q{Does not match const: false.});
+validate_ok 1000,    $bool_constant_true;
+validate_ok 'true',  $bool_constant_false, E('/', q{Does not match const: false.});
+validate_ok 'true',  $bool_constant_true;
+validate_ok 'false', $bool_constant_false;
+validate_ok 'false', $bool_constant_true, E('/', q{Does not match const: true.});
 
 done_testing;
 


### PR DESCRIPTION
With "coerce bool" activated, the result of the coercion of the string 'false' should be false and not true.
