### PR TITLE
Allow booleans to be scalar refs

### DIFF
--- a/t/booleans.t
+++ b/t/booleans.t
@@ -10,6 +10,9 @@ validate_ok {v => 0.5},     $schema, E('/v', 'Expected boolean - got number.');
 validate_ok {v => Mojo::JSON->true},  $schema;
 validate_ok {v => Mojo::JSON->false}, $schema;
 
+validate_ok {v => \1}, $schema;
+validate_ok {v => \0}, $schema;
+
 jv->coerce('booleans');
 validate_ok {v => !!1},     $schema;
 validate_ok {v => !!0},     $schema;


### PR DESCRIPTION
The JSON validation breaks when one uses `\1` or `\0` when using the
serializion in conjuction with JSON::XS, Mojo::JSON and others.

Signed-off-by: Wesley Schwengle <wesley@opndev.io>