### PR TITLE
Adds an option to disable the check that tracks the data structure being validated for recursion

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -342,7 +342,7 @@ sub _load_schema_from_url {
 
   my $tx  = $self->ua->get($url);
   my $err = $tx->error && $tx->error->{message};
-  confess "GET $url == $err"               if DEBUG and $err;
+  confess "GET $url == $err" if DEBUG and $err;
   die "[JSON::Validator] GET $url == $err" if $err;
 
   if ($cache_path
@@ -518,11 +518,11 @@ sub _resolve_ref {
     last if !$ref or ref $ref;
     $fqn = $ref =~ m!^/! ? "#$ref" : $ref;
     my ($location, $pointer) = split /#/, $fqn, 2;
-    $url     = $location = _location_to_abs($location, $url);
+    $url = $location = _location_to_abs($location, $url);
     $pointer = undef if length $location and !length $pointer;
     $pointer = url_unescape $pointer if defined $pointer;
-    $fqn     = join '#', grep defined, $location, $pointer;
-    $other   = $self->_resolve($location);
+    $fqn   = join '#', grep defined, $location, $pointer;
+    $other = $self->_resolve($location);
 
     if (defined $pointer and length $pointer and $pointer =~ m!^/!) {
       $other = Mojo::JSON::Pointer->new($other)->get($pointer);
@@ -571,7 +571,7 @@ sub _validate {
 
   my @errors;
 
-  if ( $self->recursive_data_protection ) {
+  if ($self->recursive_data_protection) {
     my $seen_addr = join ':', refaddr($schema),
       (ref $data ? refaddr $data : ++$self->{seen}{scalar});
 
@@ -904,7 +904,7 @@ sub _validate_type_integer {
   my @errors = $self->_validate_type_number($_[1], $path, $schema, 'integer');
 
   return @errors if @errors;
-  return         if $value =~ /^-?\d+$/;
+  return if $value =~ /^-?\d+$/;
   return E $path, [integer => type => data_type $value];
 }
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -576,9 +576,7 @@ sub _validate {
       (ref $data ? refaddr $data : ++$self->{seen}{scalar});
 
     # Avoid recursion
-    if ($self->{seen}{$seen_addr}) {
-      return @{$self->{seen}{$seen_addr}};
-    }
+    return @{$self->{seen}{$seen_addr}} if $self->{seen}{$seen_addr};
 
     $self->{seen}{$seen_addr} = \@errors;
   }

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -42,7 +42,7 @@ has cache_paths => sub {
 
 has formats => sub { shift->_build_formats };
 
-has recursive_data_protection => sub { return 1 };
+has recursive_data_protection => 1;
 
 sub version {
   my $self = shift;

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -1267,20 +1267,20 @@ See L<JSON::Validator::Formats> for a list of supported formats.
 
 =head2 recursive_data_protection
 
-  my $jv = $jv->recursive_data_protections( $scalar );
-  my $current_state = $jv->recursive_data_protection;
+  my $jv = $jv->recursive_data_protections( $boolean );
+  my $boolean = $jv->recursive_data_protection;
 
 Recursive data protection is active by default, however it can be deactivated
-by assigning a false value to the C<recursive_data_protection> attribute.
+by assigning a false value to the L</recursive_data_protection> attribute.
 
 Recursive data protection can have a noticeable impact on memory usage when
 validating large data structures. If you are encountering issues with memory
 and you can guarantee that you do not have any loops in your data structure
 then deactivating the recursive data protection may help.
 
-B<Note: if you deactivate the recursive data protection and try to validate
-a data structure with a loop in it you'll send your program into an infinite
-loop - if in doubt leave it active!>
+This attribute is EXPERIMENTAL and may change in a future release.
+
+B<Disclaimer: Use at your own risk, if you have any doubt then don't use it>
 
 =head2 ua
 

--- a/t/recursive_data_protection.t
+++ b/t/recursive_data_protection.t
@@ -1,0 +1,85 @@
+use Mojo::Base -strict;
+use Test::More;
+use Scalar::Util qw( refaddr );
+use JSON::Validator;
+
+
+my $original_validate;
+
+BEGIN {
+  $original_validate = \&JSON::Validator::_validate;
+}
+
+my %refCounts;
+
+{
+  no warnings 'redefine';
+
+  sub JSON::Validator::_validate {
+    my ($self, $data, $path, $schema) = @_;
+    $refCounts{refaddr($data)}++ if ref $data;
+    goto &$original_validate;
+  }
+}
+
+
+my $schema = <<'EOS';
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "level1": {
+        "type": "object",
+        "properties": {
+          "level2": {
+            "type": "object",
+            "properties": {
+              "level3": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+EOS
+
+my $object = {level1 => {level2 => {level3 => 'Test',},},};
+
+my $data = [$object, $object, $object,];
+
+
+subtest 'active' => sub {
+  my $validator = JSON::Validator->new();
+  $validator->recursive_data_protection(1);
+
+  $validator->schema($schema);
+
+  %refCounts = ();
+  my @errors = $validator->validate($data);
+
+  is($refCounts{refaddr($object->{level1}->{level2})}, 1,
+    "With recursive_data_protection active we should only see the second level once"
+  );
+};
+
+
+subtest 'inactive' => sub {
+  my $validator = JSON::Validator->new();
+  $validator->recursive_data_protection(0);
+
+  $validator->schema($schema);
+
+  %refCounts = ();
+  my @errors = $validator->validate($data);
+
+  is($refCounts{refaddr($object->{level1}->{level2})}, 3,
+    "With recursive_data_protection deactivated we should see the second level three times"
+  );
+};
+
+
+done_testing;


### PR DESCRIPTION
### Summary
This pull request adds an attribute that can be used to deactivate the active recursive data protection logic for a JSON::Validator instance.

### Motivation
When validating a data structure the recursive data protection has to track the references seen as a way to avoid infinite loops. When validating a large data structure tracking the references can use a significant amount of memory and if the caller is willing to guarantee that their data structure doesn't contain any loops then being able to disable it can reduce their process's memory usage.
