### PR TITLE
document and test that errors are spat out in a defined order

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,7 +32,7 @@ my %WriteMakefileArgs = (
     },
   },
   PREREQ_PM     => {'List::Util' => '1.45', 'Mojolicious' => '7.28', @PREREQ_YAML},
-  TEST_REQUIRES => {'Test::More' => '1.30', 'Test::Deep'  => '0', 'Math::Permute::List' => '1.007'},
+  TEST_REQUIRES => {'Test::More' => '1.30', 'Test::Deep'  => '0'},
   test          => {TESTS        => (-e 'META.yml' ? 't/*.t' : 't/*.t xt/*.t')},
 );
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,7 +32,7 @@ my %WriteMakefileArgs = (
     },
   },
   PREREQ_PM     => {'List::Util' => '1.45', 'Mojolicious' => '7.28', @PREREQ_YAML},
-  TEST_REQUIRES => {'Test::More' => '1.30', 'Test::Deep'  => '0'},
+  TEST_REQUIRES => {'Test::More' => '1.30', 'Test::Deep'  => '0', 'Math::Permute::List' => '1.007'},
   test          => {TESTS        => (-e 'META.yml' ? 't/*.t' : 't/*.t xt/*.t')},
 );
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -187,7 +187,7 @@ sub validate {
   local $self->{seen}        = {};
   local $self->{temp_schema} = [];                            # make sure random-errors.t does not fail
   my @errors = $self->_validate($_[1], '', $schema);
-  return @errors;
+  return sort { $a->path() cmp $b->path() } @errors;
 }
 
 sub validate_json {
@@ -1356,7 +1356,9 @@ DEPRECATED.
   my @errors = $jv->validate($data, $schema);
 
 Validates C<$data> against a given JSON L</schema>. C<@errors> will
-contain validation error objects or be an empty list on success.
+contain validation error objects, in a predictable order (specifically,
+ASCIIbetically sorted by the error objects' C<path>) or be an empty
+list on success.
 
 See L</ERROR OBJECT> for details.
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -186,8 +186,8 @@ sub validate {
   local $self->{schema}      = $self->_new_schema($schema);
   local $self->{seen}        = {};
   local $self->{temp_schema} = [];                            # make sure random-errors.t does not fail
-  my @errors = $self->_validate($_[1], '', $schema);
-  return sort { $a->path() cmp $b->path() } @errors;
+  my @errors = sort { $a->path cmp $b->path } $self->_validate($_[1], '', $schema);
+  return @errors;
 }
 
 sub validate_json {

--- a/t/predictable-errors.t
+++ b/t/predictable-errors.t
@@ -6,6 +6,7 @@ use Math::Permute::List;
 use Test::More;
 
 my $jv = JSON::Validator->new();
+my $num_errors;
 permute {
     $jv->schema(my $schema_text = join('',
        '{ "type": "object", "properties": {',
@@ -23,6 +24,15 @@ permute {
         [qw(/ant /bat /cat /dog)],
         "got errors in expected order with schema: $schema_text"
     );
+    if(!$num_errors) { # only run this test once
+        $num_errors = $jv->validate({
+            ant => [qw(fire soldier termite)],
+            bat => 'cricket',
+            cat => 'lion',
+            dog => 'good boy'
+        });
+        is($num_errors, 4, "in scalar context got the right number of errors");
+    }
 } (
     '"ant": { "type": "string" }',
     '"bat": { "type": "array" }',

--- a/t/predictable-errors.t
+++ b/t/predictable-errors.t
@@ -1,5 +1,4 @@
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use JSON::Validator;
 use Math::Permute::List;

--- a/t/predictable-errors.t
+++ b/t/predictable-errors.t
@@ -5,7 +5,7 @@ use JSON::Validator;
 use Math::Permute::List;
 use Test::More;
 
-my $jv = JSON::Validator->new();
+my $jv = JSON::Validator->new;
 my $num_errors;
 permute {
     $jv->schema(my $schema_text = join('',
@@ -20,7 +20,7 @@ permute {
         dog => 'good boy'
     });
     is_deeply(
-        [map { $_->path() } @errors],
+        [map { $_->path } @errors],
         [qw(/ant /bat /cat /dog)],
         "got errors in expected order with schema: $schema_text"
     );
@@ -40,4 +40,4 @@ permute {
     '"dog": { "type": "integer" }',
 );
 
-done_testing();
+done_testing;

--- a/t/predictable-errors.t
+++ b/t/predictable-errors.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+
+use JSON::Validator;
+use Math::Permute::List;
+use Test::More;
+
+my $jv = JSON::Validator->new();
+permute {
+    $jv->schema(my $schema_text = join('',
+       '{ "type": "object", "properties": {',
+       join(', ', @_),
+       '}}'
+    ));
+    my @errors = $jv->validate({
+        ant => [qw(fire soldier termite)],
+        bat => 'cricket',
+        cat => 'lion',
+        dog => 'good boy'
+    });
+    is_deeply(
+        [map { $_->path() } @errors],
+        [qw(/ant /bat /cat /dog)],
+        "got errors in expected order with schema: $schema_text"
+    );
+} (
+    '"ant": { "type": "string" }',
+    '"bat": { "type": "array" }',
+    '"cat": { "type": "object" }',
+    '"dog": { "type": "integer" }',
+);
+
+done_testing();

--- a/t/predictable-errors.t
+++ b/t/predictable-errors.t
@@ -5,38 +5,23 @@ use Math::Permute::List;
 use Test::More;
 
 my $jv = JSON::Validator->new;
+my $broken_data = {ant => [qw(fire soldier termite)], bat => 'cricket', cat => 'lion', dog => 'good boy'};
 my $num_errors;
 permute {
-    $jv->schema(my $schema_text = join('',
-       '{ "type": "object", "properties": {',
-       join(', ', @_),
-       '}}'
-    ));
-    my @errors = $jv->validate({
-        ant => [qw(fire soldier termite)],
-        bat => 'cricket',
-        cat => 'lion',
-        dog => 'good boy'
-    });
-    is_deeply(
-        [map { $_->path } @errors],
-        [qw(/ant /bat /cat /dog)],
-        "got errors in expected order with schema: $schema_text"
-    );
-    if(!$num_errors) { # only run this test once
-        $num_errors = $jv->validate({
-            ant => [qw(fire soldier termite)],
-            bat => 'cricket',
-            cat => 'lion',
-            dog => 'good boy'
-        });
-        is($num_errors, 4, "in scalar context got the right number of errors");
-    }
-} (
-    '"ant": { "type": "string" }',
-    '"bat": { "type": "array" }',
-    '"cat": { "type": "object" }',
-    '"dog": { "type": "integer" }',
+  $jv->schema(my $schema_text = join('', '{ "type": "object", "properties": {', join(', ', @_), '}}'));
+  my @errors = $jv->validate($broken_data);
+  is_deeply([map { $_->path } @errors],
+    [qw(/ant /bat /cat /dog)], "got errors in expected order with schema: $schema_text");
+  if (!$num_errors) {    # only run this test once
+    $num_errors = $jv->validate($broken_data);
+    is($num_errors, 4, "in scalar context got the right number of errors");
+  }
+}
+(
+  '"ant": { "type": "string" }',
+  '"bat": { "type": "array" }',
+  '"cat": { "type": "object" }',
+  '"dog": { "type": "integer" }',
 );
 
 done_testing;

--- a/t/predictable-errors.t
+++ b/t/predictable-errors.t
@@ -1,27 +1,25 @@
 use Mojo::Base -strict;
 
 use JSON::Validator;
-use Math::Permute::List;
 use Test::More;
 
-my $jv = JSON::Validator->new;
+my $jv          = JSON::Validator->new;
 my $broken_data = {ant => [qw(fire soldier termite)], bat => 'cricket', cat => 'lion', dog => 'good boy'};
 my $num_errors;
-permute {
-  $jv->schema(my $schema_text = join('', '{ "type": "object", "properties": {', join(', ', @_), '}}'));
+
+# The schema below gets turned into a perl hash inside JSON::Validator,
+# so looping around like this will execute the test with all kinds of
+# different internal ordering
+for (1 .. 20) {
+  $jv->schema(my $schema_text
+      = '{ "type": "object", "properties": { "ant": { "type": "string" }, "bat": { "type": "array" }, "cat": { "type": "object" }, "dog": { "type": "integer" } } }'
+  );
   my @errors = $jv->validate($broken_data);
-  is_deeply([map { $_->path } @errors],
-    [qw(/ant /bat /cat /dog)], "got errors in expected order with schema: $schema_text");
+  is_deeply([map { $_->path } @errors], [qw(/ant /bat /cat /dog)], "got errors in expected order");
   if (!$num_errors) {    # only run this test once
     $num_errors = $jv->validate($broken_data);
     is($num_errors, 4, "in scalar context got the right number of errors");
   }
 }
-(
-  '"ant": { "type": "string" }',
-  '"bat": { "type": "array" }',
-  '"cat": { "type": "object" }',
-  '"dog": { "type": "integer" }',
-);
 
 done_testing;


### PR DESCRIPTION
The code change in lib/JSON/Validator.pm appears to be redundant at
the moment, as the tests passed without it, but I'm putting it there
anyway so that any future internals changes that affect ordering don't
suddenly start causing test failures.

### Summary
The list of errors spat out by `...->validate()` are now guaranteed to be in
a predictable order, which is documented.

### Motivation
Documenting the order of errors makes it easier to write tests for error conditions.

### References
https://github.com/mojolicious/json-validator/issues/222