### PR TITLE
test and code-fix for issue 232

### DIFF
--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -314,10 +314,12 @@ sub _new_schema {
   # Compat with load_and_validate_schema()
   $attrs{specification} = delete $attrs{schema} if $attrs{schema};
 
-  my $loadable
-    = (blessed $source && ($source->can('scheme') || $source->isa('Mojo::File')))
+  my $loadable = do {
+    no warnings 'newline';
+    (blessed $source && ($source->can('scheme') || $source->isa('Mojo::File')))
     || -f $source
     || (!ref $source && $source =~ /^\w/);
+};
 
   my $store  = $self->store;
   my $schema = $loadable ? $store->get($store->load($source)) : $source;

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -314,12 +314,10 @@ sub _new_schema {
   # Compat with load_and_validate_schema()
   $attrs{specification} = delete $attrs{schema} if $attrs{schema};
 
-  my $loadable = do {
-    no warnings 'newline';
-    (blessed $source && ($source->can('scheme') || $source->isa('Mojo::File')))
-    || -f $source
+  my $loadable
+    = (blessed $source && ($source->can('scheme') || $source->isa('Mojo::File')))
+    || ($source !~ /\n/ && -f $source)
     || (!ref $source && $source =~ /^\w/);
-};
 
   my $store  = $self->store;
   my $schema = $loadable ? $store->get($store->load($source)) : $source;

--- a/t/newline-warnings.t
+++ b/t/newline-warnings.t
@@ -1,0 +1,15 @@
+use strict;
+use warnings;
+
+use Test::More;
+use JSON::Validator;
+
+my @warnings;
+$SIG{__WARN__} = sub { push @warnings, @_ };
+
+JSON::Validator->new()->schema(q!{ "type": "object" }
+!);
+
+ok(!@warnings, "no warning emitted when ->schema() method is passed a valid JSON schema ending in newline");
+
+done_testing;

--- a/t/newline-warnings.t
+++ b/t/newline-warnings.t
@@ -1,5 +1,4 @@
-use strict;
-use warnings;
+use Mojo::Base -strict;
 
 use Test::More;
 use JSON::Validator;
@@ -7,8 +6,7 @@ use JSON::Validator;
 my @warnings;
 $SIG{__WARN__} = sub { push @warnings, @_ };
 
-JSON::Validator->new()->schema(q!{ "type": "object" }
-!);
+JSON::Validator->new->schema(q!{ "type": "object" }!."\n");
 
 ok(!@warnings, "no warning emitted when ->schema() method is passed a valid JSON schema ending in newline");
 


### PR DESCRIPTION
### Summary
Tightly-scoped `no warnings 'newline'` in the chunk of code that tries to figure out whether something is a file or a string of JSON, to avoid unnecessarily spitting out a warning when it's a JSON string that ends in a newline.

### Motivation
The warning is wrong and confusing.

### References
https://github.com/mojolicious/json-validator/issues/232