### PR TITLE
add CLEAR method to J::V::Ref

### DIFF
--- a/lib/JSON/Validator/Ref.pm
+++ b/lib/JSON/Validator/Ref.pm
@@ -31,6 +31,11 @@ sub FETCH {
   return undef;
 }
 
+sub CLEAR {
+  my ($self) = @_;
+  $self->[0] = {};
+}
+
 # Make it look like there is only one key in the hash
 sub FIRSTKEY { scalar keys %{$_[0][0]}; each %{$_[0][0]} }
 sub NEXTKEY  { each %{$_[0][0]} }

--- a/t/ref.t
+++ b/t/ref.t
@@ -25,6 +25,18 @@ test(
   }
 );
 
+test(
+  'ref clear',
+  {'$ref' => '#/inner', b => 2, foo => 44},
+  {'$ref' => '#/main',  a => 1, foo => 42},
+  undef,
+  sub {
+    my ($ref, $tied) = @_;
+    %$ref = ();
+    pass 'still alive';
+  }
+);
+
 done_testing;
 
 sub test {


### PR DESCRIPTION
### Summary
JV 4.06 broke SQL::Translator::Parser::OpenAPI. This fixes it.

### Motivation
Breakage is bad.

### References
This would fix https://github.com/mohawk2/SQL-Translator-Parser-OpenAPI/issues/3
