### PR TITLE
make date-time RFC3339 compatible

### DIFF
--- a/lib/JSON/Validator/Formats.pm
+++ b/lib/JSON/Validator/Formats.pm
@@ -31,8 +31,10 @@ sub check_date {
 }
 
 sub check_date_time {
-  my @dt = $_[0] =~ m!^(\d{4})-(\d\d)-(\d\d)[T ](\d\d):(\d\d):(\d\d(?:\.\d+)?)(?:Z|([+-])(\d+):(\d+))?$!io;
+  my @dt = $_[0] =~ m!^(\d{4})-(\d\d)-(\d\d)[T ](\d\d):(\d\d):(\d\d(?:\.\d+)?)(?:Z|([+-])(\d\d):(\d\d))?$!io;
   return 'Does not match date-time format.' unless @dt;
+  return 'Time offset hour out of range.'   if defined $dt[7] and $dt[7] > 23;
+  return 'Time offset minute out of range.' if defined $dt[8] and $dt[8] > 59;
   @dt = map { s/^0//; $_ } reverse @dt[0 .. 5];
   $dt[4] -= 1;    # month are zero based
   local $@;

--- a/t/jv-formats.t
+++ b/t/jv-formats.t
@@ -27,10 +27,15 @@ subtest 'date-time' => sub {
 
   validate_ok {v => $_}, $schema
     for ('2017-03-29T23:02:55.831Z', '2017-03-29t23:02:55.01z', '2017-03-29 23:02:55-12:00',
-    '2016-02-29T23:02:55+05:00');
+    '2016-02-29T23:02:55+05:00', '2006-01-02 15:04:05+23:59', '2006-01-02 15:04:05-23:59');
 
   validate_ok {v => 'xxxx-xx-xxtxx:xx:xxz'},       $schema, E('/v', 'Does not match date-time format.');
-  validate_ok {v => '2017-03-29\t23:02:55-12:00'}, $schema, E('/v', 'Does not match date-time format.');
+  validate_ok {v => "2017-03-29\t23:02:55-12:00"}, $schema, E('/v', 'Does not match date-time format.');
+  validate_ok {v => '2017-03-29T23:02:55-12'},     $schema, E('/v', 'Does not match date-time format.');
+  validate_ok {v => '2017-03-29T23:02:55+0:0'},    $schema, E('/v', 'Does not match date-time format.');
+  validate_ok {v => '2017-03-29T23:02:55+123:00'}, $schema, E('/v', 'Does not match date-time format.');
+  validate_ok {v => '2017-03-29T23:02:55+24:00'},  $schema, E('/v', 'Time offset hour out of range.');
+  validate_ok {v => '2017-03-29T23:02:55+23:60'},  $schema, E('/v', 'Time offset minute out of range.');
   validate_ok {v => '2017-03-29T23:02:60Z'},       $schema, E('/v', 'Second out of range.');
   validate_ok {v => '2017-03-29T23:61:55Z'},       $schema, E('/v', 'Minute out of range.');
   validate_ok {v => '2017-03-29T24:02:55Z'},       $schema, E('/v', 'Hour out of range.');


### PR DESCRIPTION
RFC3339 states that the UTC offset needs to have 2 digit hour and minute offset.

Previous regexp allows for 1+ digits so "+1:1" and "-0123456789:9876543210" would be accepted.

### Summary
While using Openapi Plugin I noticed that it doesn't accept ISO timestamps. While this is fine, as Openapi spec states that the format be RFC3339, I noticed that the regexp checking the dates is too lax.

### Motivation
I see no advantage in accepting wrong time offsets like 123:567. 

### References
Discussion on IRC. Don't know how to link to it.

Spec: [OpenAPI](https://swagger.io/docs/specification/data-models/data-types/#string)
RFC: [RFC3339](https://datatracker.ietf.org/doc/rfc3339/?include_text=1)
See:
```
   time-hour       = 2DIGIT  ; 00-23
   time-minute     = 2DIGIT  ; 00-59
   time-numoffset  = ("+" / "-") time-hour ":" time-minute
```
