### PR TITLE
fix email checking

### DIFF
--- a/lib/JSON/Validator/Formats.pm
+++ b/lib/JSON/Validator/Formats.pm
@@ -74,7 +74,7 @@ sub check_email {
     my $local_part     = qr/(?:$dot_atom|$quoted_string)/o;
     my $domain         = qr/(?:$dot_atom|$domain_literal)/o;
 
-    qr/$local_part\@$domain/o;
+    qr/^$local_part\@$domain$/o;
   };
 
   return $_[0] =~ $email_rfc5322_re ? undef : 'Does not match email format.';

--- a/t/jv-formats.t
+++ b/t/jv-formats.t
@@ -79,7 +79,9 @@ subtest 'email' => sub {
   local $schema->{properties}{v}{format} = 'email';
   validate_ok {v => 'jhthorsen@cpan.org'}, $schema;
   validate_ok {v => 'foo'},                $schema, E('/v', 'Does not match email format.');
-  validate_ok {v => '用户@例子.广告'},           $schema, E('/v', 'Does not match email format.');
+  validate_ok {v => '用户@例子.广告'},             $schema, E('/v', 'Does not match email format.');
+  validate_ok {v => 'wrong@jhthorsen@cpan.org'}, $schema, E('/v', 'Does not match email format.');
+  validate_ok {v => 'wrong jhthorsen@cpan.org'}, $schema, E('/v', 'Does not match email format.');
 };
 
 subtest 'float' => sub {


### PR DESCRIPTION
### Summary

email validation accepts stuff like "a@b@c" and "something a@b somemore" as valid email addresses because there is no anchoring in the regexp.

### Motivation

I do not think those infalid addresses should be accepted.

### References

n/a
