### PR TITLE
use Mojo::File::spew instead of Mojo::File::spurt (deprecated)

### DIFF
--- a/t/load-json.t
+++ b/t/load-json.t
@@ -18,7 +18,7 @@ is_deeply [sort keys %{$jv->store->schemas}], [$jv->schema->id], 'schemas in sto
 
 my $spec = path($file)->slurp;
 $spec =~ s!"#!"person.json#! or die "Invalid spec: $spec";
-path("$file.2")->spurt($spec);
+path("$file.2")->spew($spec);
 ok eval { JSON::Validator->new->schema("$file.2") }, 'test issue #1 where $ref could not point to a file' or diag $@;
 unlink "$file.2";
 


### PR DESCRIPTION
### Summary
Use Mojo::File::spew instead of Mojo::File::spurt

### Motivation
Mojo::File::spurt has been deprecated since Mojolicious 9.34

### References
N/A
