### PR TITLE
Use negotiated content-type to select schema

### DIFF
--- a/lib/JSON/Validator/Schema/OpenAPIv3.pm
+++ b/lib/JSON/Validator/Schema/OpenAPIv3.pm
@@ -279,22 +279,33 @@ sub _validate_body {
     $val->{valid}        = $val->{content_type} ? 1 : 0;
     return E "/header/Accept", [join(', ', @{$param->{accepts}}), type => $val->{accept}] unless $val->{valid};
   }
+  my $negotiated_content_type;
   if (@{$param->{accepts}} and $val->{content_type}) {
-    my $negotiated = negotiate_content_type($param->{accepts}, $val->{content_type});
-    $val->{valid} = $negotiated ? 1 : 0;
-    return E "/$param->{name}", [join(', ', @{$param->{accepts}}) => type => $val->{content_type}] unless $negotiated;
+    $negotiated_content_type = negotiate_content_type($param->{accepts}, $val->{content_type});
+    $val->{valid} = $negotiated_content_type ? 1 : 0;
+    return E "/$param->{name}", [join(', ', @{$param->{accepts}}) => type => $val->{content_type}] unless $negotiated_content_type;
   }
   if ($param->{required} and !$val->{exists}) {
     $val->{valid} = 0;
     return E "/$param->{name}", [qw(object required)];
   }
   if ($val->{exists}) {
-    $val->{content_type} //= $param->{accepts}[0];
+    # Ensures we have a valid content-type so we can select a schema
+    # This can happen if the negotiation fails (e.g. content-type is empty)
+    $negotiated_content_type //= $param->{accepts}[0];
+
+    # Mutate request content-type if one was not set
+    $val->{content_type} //= $negotiated_content_type;
+
     local $self->{coerce}{arrays} = 1
       if $val->{content_type} =~ m!^(application/x-www-form-urlencoded|multipart/form-data)$!;
+
     local $self->{"validate_$direction"} = 1;
+
+    my $body_params = $param->{content}{$negotiated_content_type};
     my @errors = map { $_->path(_prefix_error_path($param->{name}, $_->path)); $_ }
-      $self->validate($val->{value}, $param->{content}{$val->{content_type}}{schema});
+      $self->validate($val->{value}, $body_params->{schema});
+
     $val->{valid} = @errors ? 0 : 1;
     return @errors;
   }

--- a/lib/JSON/Validator/Schema/OpenAPIv3.pm
+++ b/lib/JSON/Validator/Schema/OpenAPIv3.pm
@@ -298,7 +298,7 @@ sub _validate_body {
     $val->{content_type} //= $negotiated_content_type;
 
     local $self->{coerce}{arrays} = 1
-      if $val->{content_type} =~ m!^(application/x-www-form-urlencoded|multipart/form-data)$!;
+      if $val->{content_type} =~ m!^(application/x-www-form-urlencoded|multipart/form-data)\s*(;|$)!;
 
     local $self->{"validate_$direction"} = 1;
 

--- a/t/openapiv3-coerce-array.t
+++ b/t/openapiv3-coerce-array.t
@@ -23,6 +23,12 @@ subtest 'already an array' => sub {
   is "@errors", "", "valid";
 };
 
+subtest 'array coercion with multipart/form-data boundary' => sub {
+  $body   = {exists => 1, value => {id => 42}, content_type => 'multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW'};
+  @errors = $schema->validate_request([post => '/test'], {body => \&body});
+  is "@errors", "", "valid with boundary parameter";
+};
+
 subtest 'parameter array schema is $ref' => sub {
   $query  = {exists => 1, value => [42, 43]};
   @errors = $schema->validate_request([get => '/test'], {query => \&query});
@@ -51,6 +57,13 @@ paths:
         required: true
         content:
           application/x-www-form-urlencoded:
+            schema:
+              properties:
+                id:
+                  type: array
+                  items:
+                    type: integer
+          multipart/form-data:
             schema:
               properties:
                 id:

--- a/t/openapiv3-content-types.t
+++ b/t/openapiv3-content-types.t
@@ -1,0 +1,206 @@
+use Mojo::Base -strict;
+use JSON::Validator;
+use Test::More;
+
+my $schema = JSON::Validator->new->schema('data://main/spec.yaml')->schema;
+my ($body, @errors);
+
+sub body {$body}
+
+subtest '*/* w/ required body' => sub {
+  subtest 'content-type is missing' => sub {
+    $body = {exists => 0};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body: Missing property.", 'invalid request body';
+
+    $body = {exists => 1, value => {name => 'kitty'}};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "", 'valid request body';
+
+    $body = {exists => 1, value => {age => 42}};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body/name: Missing property.", 'invalid request body';
+  };
+
+  subtest 'content-type is empty string' => sub {
+    $body = {exists => 0, content_type => ''};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body: Missing property.", 'invalid request body';
+
+    $body = {exists => 1, value => {name => 'kitty'}, content_type => ''};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "", 'valid request body';
+
+    $body = {exists => 1, value => {age => 42}, content_type => ''};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body/name: Missing property.", 'invalid request body';
+  };
+
+  subtest 'content-type is application/json' => sub {
+    $body = {exists => 0};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body: Missing property.", 'invalid request body';
+
+    $body = {exists => 1, value => {name => 'kitty'}, content_type => 'application/json'};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "", 'valid request body';
+
+    $body = {exists => 1, value => {age => 42}, content_type => 'application/json'};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body/name: Missing property.", 'invalid request body';
+  };
+
+  subtest 'content-type is application/json; charset=utf-8' => sub {
+    $body = {exists => 0};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body: Missing property.", 'invalid request body';
+
+    $body = {exists => 1, value => {name => 'kitty'}, content_type => 'application/json; charset=utf-8'};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "", 'valid request body';
+
+    $body = {exists => 1, value => {age => 42}, content_type => 'application/json; charset=utf-8'};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body/name: Missing property.", 'invalid request body';
+  };
+};
+
+subtest 'application/json w/ body' => sub {
+  subtest 'content-type is missing' => sub {
+    $body = {exists => 0};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "/body: Missing property.", 'invalid request body';
+
+    $body = {exists => 1, value => {name => 'kitty'}};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "", 'valid request body';
+
+    $body = {exists => 1, value => {age => 42}};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body/name: Missing property.", 'invalid request body';
+  };
+
+  subtest 'content-type is empty string' => sub {
+    $body = {exists => 0, content_type => ''};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "/body: Missing property.", 'invalid request body';
+
+    $body = {exists => 1, value => {name => 'kitty'}, content_type => ''};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "", 'valid request body';
+
+    $body = {exists => 1, value => {age => 42}, content_type => ''};
+    @errors = $schema->validate_request([post => '/pets_any'], {body => \&body});
+    is "@errors", "/body/name: Missing property.", 'invalid request body';
+  };
+
+  subtest 'content-type is application/json' => sub {
+    $body = {exists => 0};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "/body: Missing property.", 'invalid request body';
+
+    $body = {exists => 1, value => {name => 'kitty'}, content_type => 'application/json'};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "", 'valid request body';
+
+    $body = {exists => 1, value => {age => 42}, content_type => 'application/json'};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "/body/name: Missing property.", 'invalid request body';
+  };
+
+  subtest 'content-type is application/json; charset=utf-8' => sub {
+    $body = {exists => 1, value => {name => 'kitty'}, content_type => 'application/json; charset=utf-8'};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "", 'valid request body';
+
+    $body = {exists => 1, value => {age => 42}, content_type => 'application/json; charset=utf-8'};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "/body/name: Missing property.", 'invalid request body';
+  };
+
+  subtest 'content-type is application/xml' => sub {
+    $body = {exists => 0, content_type => 'application/xml'};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "/body: Expected application/json - got application/xml.", 'invalid request body';
+
+    $body = {exists => 1, value => {name => 'kitty'}, content_type => 'application/xml'};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "/body: Expected application/json - got application/xml.", 'invalid request body';
+
+    $body = {exists => 1, value => {age => 42}, content_type => 'application/xml'};
+    @errors = $schema->validate_request([post => '/pets_json'], {body => \&body});
+    is "@errors", "/body: Expected application/json - got application/xml.", 'invalid request body';
+  };
+};
+
+subtest 'w/o body' => sub {
+  $body = {exists => 0};
+  @errors = $schema->validate_request([post => '/pets/publish'], {body => \&body});
+  is "@errors", "", 'valid request body';
+
+  $body = {exists => 0, content_type => ''};
+  @errors = $schema->validate_request([post => '/pets/publish'], {body => \&body});
+  is "@errors", "", 'valid request body';
+
+  $body = {exists => 0, content_type => 'application/xml'};
+  @errors = $schema->validate_request([post => '/pets/publish'], {body => \&body});
+  is "@errors", "", 'valid request body';
+
+  $body = {exists => 0, content_type => 'application/json; charset=utf-8'};
+  @errors = $schema->validate_request([post => '/pets/publish'], {body => \&body});
+  is "@errors", "", 'valid request body';
+};
+
+done_testing;
+
+__DATA__
+@@ spec.yaml
+openapi: 3.0.0
+info:
+  title: Style And Explode
+  version: ""
+paths:
+  /pets_any:
+    post:
+      requestBody:
+        required: true
+        content:
+          "*/*":
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: success
+          schema:
+            type: object
+  /pets_json:
+    post:
+      requestBody:
+        required: true
+        content:
+          "application/json":
+            schema:
+              type: object
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+      responses:
+        "200":
+          description: success
+          schema:
+            type: object
+  /pets/publish:
+    post:
+      description: example of endpoint with no request body
+      responses:
+        "200":
+          description: success
+          schema:
+            type: object


### PR DESCRIPTION
### Summary
- Fix regex on content-type for array coercion
- Use negotiated content-type to select schema from api spec

### Motivation
Adding parameters to content-type (e.g. `json/application; charset=utf8`) causes the validation to be completely bypassed. `multipart/form` in fact requires to have a `boundary` option.

The current implementation appears to [use the content type provided by the client](https://github.com/jhthorsen/json-validator/pull/289/files#diff-36bb0f5c803b74d31c0f832dce4c19d24584626bdbe8166e9eb555af1eb3931aL297). This means that if the content type has additional parameters, it doesn't find a schema to validate against, so just uses an empty schema.

By using the content-type from the negotiation (and thus originally derived from the spec), in theory we should always find an appropriate schema.

However, as there's also a bug in the `mojolicious-plugin-openapi` which means we don't validate file uploads, this will probably break stuff unless deployed at the same time as https://github.com/jhthorsen/mojolicious-plugin-openapi/pull/266 , which might make the packaging/dependency fun.

Possibly an an alternative could be to disallow any parameters going into `json-validator`, and force the openapi plugin to strip them instead.

### References
Related: https://github.com/jhthorsen/json-validator/pull/284, 

I think this also fixes https://github.com/jhthorsen/mojolicious-plugin-openapi/issues/261