### PR TITLE
Updated idn-email format verification to allow periods in local part

### DIFF
--- a/lib/JSON/Validator/Formats.pm
+++ b/lib/JSON/Validator/Formats.pm
@@ -93,15 +93,19 @@ sub check_idn_email {
 
   local $@;
   my $err = eval {
-    my @email = split /@/, $_[0], 2;
+    my ($local_part, $domain) = split /@/, $_[0], 2;
+    $local_part = join '.', map {
+      Net::IDN::Encode::to_ascii($_)
+    } split( /\./, $local_part // '');
+
     check_email(
       join '@',
-      Net::IDN::Encode::to_ascii($email[0]        // ''),
-      Net::IDN::Encode::domain_to_ascii($email[1] // ''),
+      $local_part,
+      Net::IDN::Encode::domain_to_ascii($domain // ''),
     );
   };
 
-  return $err ? 'Does not match idn-email format.' : $@ || undef;
+  return $err || $@ ? 'Does not match idn-email format.' : undef;
 }
 
 sub check_idn_hostname {

--- a/t/jv-formats.t
+++ b/t/jv-formats.t
@@ -117,6 +117,43 @@ subtest 'idn-email' => sub {
   local $TODO = eval 'require Net::IDN::Encode;1' ? undef : 'Missing module';
   local $schema->{properties}{v}{format} = 'idn-email';
   validate_ok {v => decode('UTF-8', '用户@')}, $schema, E('/v', 'Does not match idn-email format.');
+
+  # --- Valid IDN Email Addresses (Domain Variations) ---
+  validate_ok {v => decode('UTF-8', 'user@bücher.example')}, $schema;
+  validate_ok {v => decode('UTF-8', 'user@xn--bcher-kva.example')}, $schema;
+  validate_ok {v => decode('UTF-8', 'test.user@δοκιμή.example')}, $schema;
+  validate_ok {v => decode('UTF-8', 'info@例.jp')}, $schema;
+  validate_ok {v => decode('UTF-8', 'john.doe@例子.com')}, $schema;
+  validate_ok {v => decode('UTF-8', 'user@müller.com')}, $schema;
+  validate_ok {v => decode('UTF-8', 'user@test-bücher.com')}, $schema;
+  validate_ok {v => decode('UTF-8', 'user@xn--test-bcher-kvb.com')}, $schema;
+
+  # --- Valid IDN Email Addresses (Local-Part Variations) ---
+  validate_ok {v => decode('UTF-8', 'simple@bücher.example')}, $schema;
+  validate_ok {v => decode('UTF-8', 'user.name@bücher.example')}, $schema;
+  validate_ok {v => decode('UTF-8', 'user_name@bücher.example')}, $schema;
+  validate_ok {v => decode('UTF-8', 'user-name@bücher.example')}, $schema;
+  validate_ok {v => decode('UTF-8', 'user+alias@bücher.example')}, $schema;
+  validate_ok {v => decode('UTF-8', '!#$%&\'*+-/=?^_{}|~@bücher.example')}, $schema;
+  validate_ok {v => decode('UTF-8', '佐藤@例.jp')}, $schema;
+  validate_ok {v => decode('UTF-8', 'пользователь@пример.рф')}, $schema;
+  validate_ok {v => decode('UTF-8', 'user.佐藤@bücher.example')}, $schema;
+
+
+  # --- Invalid IDN Email Addresses (Domain Variations) ---
+  validate_ok {v => decode('UTF-8', 'user@bücher-.example')}, $schema, E('/v', 'Does not match idn-email format.');
+  validate_ok {v => decode('UTF-8', 'user@-bücher.example')}, $schema, E('/v', 'Does not match idn-email format.');
+  validate_ok {v => decode('UTF-8', 'user@bücher..example')}, $schema, E('/v', 'Does not match idn-email format.');
+  validate_ok {v => decode('UTF-8', 'user@bücher_example.com')}, $schema, E('/v', 'Does not match idn-email format.');
+  validate_ok {v => decode('UTF-8', 'user@bücher.com.')}, $schema, E('/v', 'Does not match idn-email format.');
+
+  # --- Invalid IDN Email Addresses (Local-Part Variations) ---
+  validate_ok {v => decode('UTF-8', '.user@bücher.example')}, $schema, E('/v', 'Does not match idn-email format.');
+  validate_ok {v => decode('UTF-8', 'user..name@bücher.example')}, $schema, E('/v', 'Does not match idn-email format.');
+  validate_ok {v => decode('UTF-8', 'user name@bücher.example')}, $schema, E('/v', 'Does not match idn-email format.');
+  validate_ok {v => decode('UTF-8', 'user,@bücher.example')}, $schema, E('/v', 'Does not match idn-email format.');
+  validate_ok {v => decode('UTF-8', 'user(comment)@bücher.example')}, $schema, E('/v', 'Does not match idn-email format.');
+  validate_ok {v => decode('UTF-8', '"user.name@bücher.example')}, $schema, E('/v', 'Does not match idn-email format.');
 };
 
 subtest 'idn-hostname' => sub {


### PR DESCRIPTION
### Summary
This pull request corrects the idn-email format validation to properly handle local-parts containing periods.

### Motivation
While testing the idn-email format, I discovered that many common and valid email addresses, such as firstname.lastname@domain.com, were incorrectly failing validation.

The root cause was that the check_idn_email function passed the entire local-part of the email as a single string to Net::IDN::Encode::to_ascii. This function is intended for single domain labels and is not designed to handle periods, causing it to fail.

This change corrects the logic by:

1. Splitting the local-part of the email by periods.
2. Applying the to_ascii encoding to each segment individually.
3. Rejoining the encoded segments with periods.

This ensures that the validator no longer fails on valid emails containing a . in the local-part, making the idn-email format check more robust and accurate.