### PR TITLE
Fix nondeterministic false errors from the recursive_data_protection cache

### DIFF
--- a/lib/JSON/Validator/Schema.pm
+++ b/lib/JSON/Validator/Schema.pm
@@ -372,8 +372,13 @@ sub _validate {
   my @errors;
   if ($self->recursive_data_protection and 2 == grep { ref $_ && !is_bool($_) } $data, $schema) {
     my $seen_addr = "$schema:$data";
-    return @{$self->{seen}{$seen_addr}} if $self->{seen}{$seen_addr};    # Avoid recursion
-    $self->{seen}{$seen_addr} = \@errors;
+    my $seen      = $self->{seen}{$seen_addr};
+    return @{$seen->[0]} if $seen;    # Avoid recursion
+    # Keep $schema and $data referenced for the rest of this validation run, so
+    # their memory addresses cannot be reused by transient (merged) schemas built
+    # later while following $ref/$dynamicRef. Otherwise this address-based cache
+    # key collides with a freed entry and returns stale errors (GH #272).
+    $self->{seen}{$seen_addr} = [\@errors, $schema, $data];
   }
 
   local $_[1] = $data->TO_JSON if blessed $data and $data->can('TO_JSON');

--- a/t/issue-272-recursive-data-protection.t
+++ b/t/issue-272-recursive-data-protection.t
@@ -1,0 +1,45 @@
+use Mojo::Base -strict;
+use JSON::Validator::Schema::OpenAPIv3;
+use Mojo::JSON qw(true);
+use Test::More;
+
+# Regression test for GH #272 ("heisenbug with openapi 3.1.* schema").
+#
+# Validating an OpenAPI 3.1 document whose parameter uses a $ref schema
+# intermittently produced a false "/components/parameters/Id/$ref: Missing
+# property." error. Root cause: recursive_data_protection's "seen" cache keyed on
+# stringified memory addresses ("$schema:$data"); transient merged-schema hashrefs
+# (built while following the meta-schema's $refs) were freed mid-validation and
+# their addresses reused, colliding with stale cached error lists.
+#
+# It is a heisenbug (address reuse, independent of the hash seed), so we validate
+# many times and assert the document is *always* valid.
+
+sub spec {
+  return {
+    openapi    => '3.1.0',
+    info       => {version => '1.0', title => 'whatever'},
+    components => {
+      parameters => {
+        Id => {in => 'path', name => 'id', required => true, schema => {'$ref' => '#/components/schemas/IdType'}},
+      },
+      schemas => {IdType => {type => 'integer'}},
+    },
+  };
+}
+
+my $spec_url   = 'https://spec.openapis.org/oas/3.1/schema/2021-05-20';
+my $iterations = 500;
+
+my (%errors, $failures);
+for (1 .. $iterations) {
+  my $schema = JSON::Validator::Schema::OpenAPIv3->new(spec(), specification => $spec_url);
+  next unless my @e = @{$schema->errors};
+  $failures++;
+  $errors{"$_"}++ for @e;
+}
+
+is $failures, undef, "valid 3.1 \$ref parameter stays valid across $iterations validations (#272)"
+  or diag "spurious errors: " . join(', ', map {"$_ x$errors{$_}"} sort keys %errors);
+
+done_testing;


### PR DESCRIPTION
### Summary

Keep the cached `$schema` and `$data` referenced for the duration of the validation by storing
them in the cache value (`[\@errors, $schema, $data]`), so their addresses cannot be reused by
later transient schemas in the same run. This preserves the existing memoization and
cyclic-data-recursion semantics - `t/recursive_data_protection.t` and `t/validate-recursive.t`
still pass - and only removes the address-reuse collision.

### Root cause

`recursive_data_protection`'s `seen` cache in `JSON::Validator::Schema::_validate` keys on
stringified memory addresses (`"$schema:$data"`) and keeps entries for the whole validation. When
a schema follows many `$ref`s (the OpenAPI 3.1 meta-schema does), `_state` builds transient merged
schema hashrefs; these are freed mid-validation and their addresses get reused, so a later cache
key collides with a freed entry and returns a stale error list - here the discarded
`if: { required: ["$ref"] }` branch error. Because it depends on address reuse, the failure is
intermittent and unrelated to `PERL_PERTURB_KEYS`/hash ordering.

### References

#272
