### PR TITLE
Bundle the available OpenAPI v3.0 schema (2021-09-28) as the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Here is the list of the bundled specifications:
 
     Web page: [https://openapis.org](https://openapis.org)
 
-    `$ref`: [https://spec.openapis.org/oas/3.0/schema/2019-04-02](https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v3.0/schema.json)
+    `$ref`: [https://spec.openapis.org/oas/3.0/schema/2021-09-28](https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v3.0/schema.json)
 
     This specification is still EXPERIMENTAL.
 

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -15,7 +15,7 @@ our %SCHEMAS = (
   'http://json-schema.org/draft-07/schema#'             => '+Draft7',
   'https://json-schema.org/draft/2019-09/schema'        => '+Draft201909',
   'http://swagger.io/v2/schema.json'                    => '+OpenAPIv2',
-  'https://spec.openapis.org/oas/3.0/schema/2019-04-02' => '+OpenAPIv3',
+  'https://spec.openapis.org/oas/3.0/schema/2021-09-28' => '+OpenAPIv3',
   'https://spec.openapis.org/oas/3.1/schema/2021-05-20' => '+OpenAPIv3',
 );
 
@@ -117,7 +117,7 @@ sub _new_schema {
       $attrs{specification} ||= $spec;
     }
     elsif ($spec->{openapi} and $spec->{openapi} =~ m!^3\.0\.\d+$!) {
-      $spec = 'https://spec.openapis.org/oas/3.0/schema/2019-04-02';
+      $spec = 'https://spec.openapis.org/oas/3.0/schema/2021-09-28';
     }
   }
 
@@ -257,7 +257,7 @@ C<$ref>: L<http://swagger.io/v2/schema.json#>
 
 Web page: L<https://openapis.org>
 
-C<$ref>: L<https://spec.openapis.org/oas/3.0/schema/2019-04-02|https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v3.0/schema.json>
+C<$ref>: L<https://spec.openapis.org/oas/3.0/schema/2021-09-28|https://github.com/OAI/OpenAPI-Specification/blob/master/schemas/v3.0/schema.json>
 
 This specification is still EXPERIMENTAL.
 

--- a/lib/JSON/Validator/Schema/OpenAPIv3.pm
+++ b/lib/JSON/Validator/Schema/OpenAPIv3.pm
@@ -6,7 +6,7 @@ use Mojo::JSON            qw(false true);
 use Mojo::Path;
 
 has moniker       => 'openapiv3';
-has specification => 'https://spec.openapis.org/oas/3.0/schema/2019-04-02';
+has specification => 'https://spec.openapis.org/oas/3.0/schema/2021-09-28';
 
 require JSON::Validator::Schema::OpenAPIv2;
 *coerce                           = \&JSON::Validator::Schema::OpenAPIv2::coerce;
@@ -436,7 +436,7 @@ See L<JSON::Validator::Schema::OpenAPIv2/SYNOPSIS>.
 
 =head1 DESCRIPTION
 
-This class represents L<https://spec.openapis.org/oas/3.0/schema/2019-04-02>.
+This class represents L<https://spec.openapis.org/oas/3.0/schema/2021-09-28>.
 
 =head1 ATTRIBUTES
 
@@ -458,7 +458,7 @@ Used to get/set the moniker for the given schema. Default value is "openapiv3".
   my $str    = $schema->specification;
   my $schema = $schema->specification($str);
 
-Defaults to "L<https://spec.openapis.org/oas/3.0/schema/2019-04-02>".
+Defaults to "L<https://spec.openapis.org/oas/3.0/schema/2021-09-28>".
 
 =head1 METHODS
 

--- a/lib/JSON/Validator/cache/4550dd8afbfee9e71377b45f5fea42ce
+++ b/lib/JSON/Validator/cache/4550dd8afbfee9e71377b45f5fea42ce
@@ -1,7 +1,7 @@
 {
-  "id": "https://spec.openapis.org/oas/3.0/schema/2019-04-02",
+  "id": "https://spec.openapis.org/oas/3.0/schema/2021-09-28",
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Validation schema for OpenAPI Specification 3.0.X.",
+  "description": "The description of OpenAPI v3.0.x documents, as defined by https://spec.openapis.org/oas/v3.0.3",
   "type": "object",
   "required": [
     "openapi",
@@ -1358,9 +1358,8 @@
           "description": "Bearer",
           "properties": {
             "scheme": {
-              "enum": [
-                "bearer"
-              ]
+              "type": "string",
+              "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
             }
           }
         },
@@ -1374,9 +1373,8 @@
           "properties": {
             "scheme": {
               "not": {
-                "enum": [
-                  "bearer"
-                ]
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
               }
             }
           }
@@ -1489,7 +1487,8 @@
     "PasswordOAuthFlow": {
       "type": "object",
       "required": [
-        "tokenUrl"
+        "tokenUrl",
+        "scopes"
       ],
       "properties": {
         "tokenUrl": {
@@ -1516,7 +1515,8 @@
     "ClientCredentialsFlow": {
       "type": "object",
       "required": [
-        "tokenUrl"
+        "tokenUrl",
+        "scopes"
       ],
       "properties": {
         "tokenUrl": {
@@ -1544,7 +1544,8 @@
       "type": "object",
       "required": [
         "authorizationUrl",
-        "tokenUrl"
+        "tokenUrl",
+        "scopes"
       ],
       "properties": {
         "authorizationUrl": {
@@ -1628,7 +1629,14 @@
         "headers": {
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/Header"
+            "oneOf": [
+              {
+                "$ref": "#/definitions/Header"
+              },
+              {
+                "$ref": "#/definitions/Reference"
+              }
+            ]
           }
         },
         "style": {

--- a/t/openapiv3-basic.t
+++ b/t/openapiv3-basic.t
@@ -9,7 +9,7 @@ my $schema = JSON::Validator::Schema::OpenAPIv3->new;
 my ($body, $p, @errors);
 
 subtest 'basic' => sub {
-  is $schema->specification, 'https://spec.openapis.org/oas/3.0/schema/2019-04-02', 'specification';
+  is $schema->specification, 'https://spec.openapis.org/oas/3.0/schema/2021-09-28', 'specification';
   is_deeply $schema->coerce, {booleans => 1, numbers => 1, strings => 1}, 'default coercion';
 
   $schema = JSON::Validator->new->schema($cwd->child(qw(spec v3-petstore.json)))->schema;

--- a/t/openapiv3-bundled-spec.t
+++ b/t/openapiv3-bundled-spec.t
@@ -1,0 +1,38 @@
+use Mojo::Base -strict;
+use JSON::Validator;
+use JSON::Validator::Schema::OpenAPIv3;
+use Test::More;
+
+# Issue #286: the default OpenAPI v3.0 specification must be bundled with the
+# distribution and resolvable offline. Any attempt to fetch it over the network
+# means the bundled spec is missing.
+
+subtest 'default specification is the bundled 2021-09-28 spec' => sub {
+  my $schema = JSON::Validator::Schema::OpenAPIv3->new;
+  is $schema->specification, 'https://spec.openapis.org/oas/3.0/schema/2021-09-28', 'specification';
+};
+
+subtest 'default specification loads from the bundle without network' => sub {
+  my $jv = JSON::Validator->new;
+  $jv->store->ua(FakeUA->new);    # blow up if a network request is attempted
+
+  my $url = 'https://spec.openapis.org/oas/3.0/schema/2021-09-28';
+  my $id  = $jv->store->load($url);
+  is $id, $url, 'loaded from bundle';
+  is $jv->store->get($id)->{id}, $url, 'bundled schema id matches url';
+};
+
+subtest 'openapi 3.0.x documents are validated against the bundled default' => sub {
+  my $jv = JSON::Validator->new;
+  $jv->store->ua(FakeUA->new);    # blow up if a network request is attempted
+
+  my $schema = $jv->schema({openapi => '3.0.3', info => {title => 't', version => '1'}, paths => {}})->schema;
+  is $schema->specification, 'https://spec.openapis.org/oas/3.0/schema/2021-09-28', 'detected default';
+  is_deeply $schema->errors, [], 'valid minimal 3.0 document';
+};
+
+done_testing;
+
+package FakeUA;
+sub new { bless {}, shift }
+sub get { Test::More::BAIL_OUT('network access attempted - bundled OpenAPI v3.0 spec is missing') }

--- a/t/openapiv3-file.t
+++ b/t/openapiv3-file.t
@@ -10,7 +10,7 @@ my $schema = JSON::Validator::Schema::OpenAPIv3->new;
 my ($body, $p, @errors);
 
 subtest 'basic' => sub {
-  is $schema->specification, 'https://spec.openapis.org/oas/3.0/schema/2019-04-02', 'specification';
+  is $schema->specification, 'https://spec.openapis.org/oas/3.0/schema/2021-09-28', 'specification';
   is_deeply $schema->coerce, {booleans => 1, numbers => 1, strings => 1}, 'default coercion';
 
   $schema = JSON::Validator->new->schema('data://main/spec.yaml')->schema;


### PR DESCRIPTION
### Summary

- Bundle the OpenAPI v3.0 schema revision `2021-09-28` and make it the default specification used to validate `3.0.x` documents.
- Drop the previous default `2019-04-02` and its bundled meta-schema, since that revision is no longer reachable and has been superseded.
- Add a regression test that the default v3.0 spec resolves from the bundle without any network access.

### Motivation

The default OpenAPI v3.0 specification `https://spec.openapis.org/oas/3.0/schema/2019-04-02` is no longer
available, so validating a `3.0.x` document that was not already cached fails when the store tries to fetch the
meta-schema. `https://spec.openapis.org/oas/3.0/schema/2021-09-28` is the latest published v3.0.x revision and is
available, so it is bundled and used as the default instead.

The two revisions describe the same OpenAPI 3.0.x format (same draft-04 dialect, same top-level structure), so the
existing test fixtures continue to validate unchanged.

Note one backward-incompatibility: code that explicitly pinned `specification => '.../2019-04-02'` will no longer
get a bundled offline copy and would attempt to fetch that (now unreachable) URL. This is the intended consequence
of removing the superseded revision.

### References

#286