### PR TITLE
Make Net::IDN::Encode and Data::Validate::* optional (recommends) — fixes install on Perl 5.38+

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for perl distribution JSON-Validator
 
+5.19 Not Released
+ - Make Net::IDN::Encode, Data::Validate::Domain and Data::Validate::IP optional so installation works on Perl 5.38+ #296
+
 5.18 2026-06-08T09:53:00
  - Bundle OpenAPI v3.0 schema 2021-09-28 as default #295, #286
    Contributor: Henrik Andersen

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,12 +15,9 @@ my %WriteMakefileArgs = (
   LICENSE       => 'artistic_2',
   VERSION_FROM  => 'lib/JSON/Validator.pm',
   PREREQ_PM   => {
-    'perl'                   => 'v5.16.0',
-    'Data::Validate::Domain' => '0.11',
-    'Data::Validate::IP'     => '0.27',
-    'List::Util'             => '1.45',
-    'Mojolicious'            => '9.34',
-    'Net::IDN::Encode'       => '2.500',
+    'perl'        => 'v5.16.0',
+    'List::Util'  => '1.45',
+    'Mojolicious' => '9.34',
     @PREREQ_YAML
   },
   TEST_REQUIRES => {'Test::More' => '1.30', 'Test::Deep' => '0'},
@@ -28,7 +25,16 @@ my %WriteMakefileArgs = (
     'dynamic_config' => 0,
     'meta-spec'      => {version   => 2},
     'no_index'       => {directory => [qw(examples t)]},
-    'prereqs'        => {runtime   => {requires => {perl => '5.016'}}},
+    'prereqs'        => {
+      runtime => {
+        requires   => {perl => '5.016'},
+        recommends => {
+          'Data::Validate::Domain' => '0.11',
+          'Data::Validate::IP'     => '0.27',
+          'Net::IDN::Encode'       => '2.500',
+        },
+      },
+    },
     'resources'      => {
       bugtracker => {web => "$GITHUB_URL/issues"},
       homepage   => $GITHUB_URL,


### PR DESCRIPTION
Fixes #296.

`Net::IDN::Encode`, `Data::Validate::Domain`, and `Data::Validate::IP` are
currently hard runtime `requires`, but `JSON::Validator::Formats` already
loads all three via `eval 'require'` and guards every call site, returning
`_module_missing(...)` when one is absent. They are genuinely optional at
runtime.

The hard `requires` on `Net::IDN::Encode` breaks installation on Perl 5.38+:
its XS uses `uvuni_to_utf8_flags`, removed in 5.38, and the fixes sit in
unmerged upstream PRs. So a dependency that isn't needed at runtime makes
JSON::Validator itself uninstallable on modern Perl.

This moves the three from `PREREQ_PM` to `runtime/recommends` in the
META. The test suite already marks the relevant format checks `TODO` when a
module is missing, so nothing regresses.

## Testing

Verified in throwaway Docker containers across Perl 5.36, 5.38 and 5.42.2,
with the recommended modules present and absent:

| Perl   | Net::IDN::Encode builds | install BEFORE (hard requires) | install AFTER (recommends) | `make test` AFTER |
|--------|-------------------------|--------------------------------|----------------------------|-------------------|
| 5.36.3 | yes                     | pass                           | pass                       | pass              |
| 5.38.5 | no (`uvuni_to_utf8_flags`) | **fail**                    | pass                       | pass              |
| 5.42.2 | no (`uvuni_to_utf8_flags`) | **fail**                    | pass                       | pass              |

On 5.42.2 with all three modules absent: `All tests successful. Files=84,
Tests=805`. With modules present, the hostname/ipv4/ipv6/idn formats validate
for real; when absent they degrade to TODO as before.
