### PR TITLE
Fix OpenAPIv3 string coercion regression

### DIFF
--- a/lib/JSON/Validator/Schema/OpenAPIv3.pm
+++ b/lib/JSON/Validator/Schema/OpenAPIv3.pm
@@ -407,7 +407,8 @@ sub _validate_type_object_response {
 }
 
 sub _validate_type_string {
-  my ($self, $val, $state) = @_;
+  my $self = shift;
+  my ($val, $state) = @_;
 
   return () if $state->{schema}{nullable} && !defined $val;
 
@@ -419,7 +420,9 @@ sub _validate_type_string {
     return E $state->{path}, [string => type => data_type $val];
   }
 
-  return $self->SUPER::_validate_type_string($val, $state);
+  # Pass @_ (not the lexical copies) so SUPER's in-place coercion of $_[1]
+  # propagates back to the caller's aliased value.
+  return $self->SUPER::_validate_type_string(@_);
 }
 
 1;

--- a/t/openapiv3-file.t
+++ b/t/openapiv3-file.t
@@ -1,6 +1,7 @@
 use Mojo::Base -strict;
 use JSON::Validator::Schema::OpenAPIv3;
 use Mojo::File;
+use Mojo::JSON qw(encode_json);
 use Mojo::Upload;
 use Test::Deep;
 use Test::More;
@@ -91,6 +92,13 @@ subtest 'file placehodler in non-file string' => sub {
   $body = {exists => 1,value => {name => $file } };
   @errors = $schema->validate_request([post => '/submit'], {body => \&body});
   is "@errors", "/body/name: Expected string - got file.", 'valid file';
+};
+
+subtest 'integer is coerced to string' => sub {
+  $body = {exists => 1, value => {name => 42}};
+  @errors = $schema->validate_request([post => '/submit'], {body => \&body});
+  is "@errors", "", 'valid';
+  is encode_json($body->{value}), '{"name":"42"}', 'value is coerced to string';
 };
 
 done_testing;


### PR DESCRIPTION
### Summary
The override of _validate_type_string introduced in a8fe5fa unpacked @_ into lexical copies and passed those to SUPER.

However, the call to SUPER mutates the values in @_, which I'd incorrectly assumed it didn't.

Credit to @NGEfreak for spotting and the actual fix.

### References
Fixes https://github.com/jhthorsen/json-validator/issues/298