### PR TITLE
Fix boolean exclusiveMinimum/exclusiveMaximum in OpenAPI v3.0 #273

### DIFF
--- a/lib/JSON/Validator/Schema/OpenAPIv3.pm
+++ b/lib/JSON/Validator/Schema/OpenAPIv3.pm
@@ -1,7 +1,7 @@
 package JSON::Validator::Schema::OpenAPIv3;
 use Mojo::Base 'JSON::Validator::Schema::Draft201909';
 
-use JSON::Validator::Util qw(E data_type negotiate_content_type schema_type);
+use JSON::Validator::Util qw(E data_type is_num negotiate_content_type schema_type);
 use Mojo::JSON            qw(false true);
 use Mojo::Path;
 
@@ -314,6 +314,22 @@ sub _validate_body {
 }
 
 sub _validate_id { }
+
+# OpenAPI v3.0 uses draft4 semantics, where exclusiveMinimum/exclusiveMaximum
+# are booleans modifying minimum/maximum, while OpenAPI v3.1 uses numbers
+sub _validate_number_max {
+  my $exclusive = $_[2]->{schema}{exclusiveMaximum} // '';
+  return is_num($exclusive)
+    ? JSON::Validator::Schema::Draft6::_validate_number_max(@_)
+    : JSON::Validator::Schema::Draft4::_validate_number_max(@_);
+}
+
+sub _validate_number_min {
+  my $exclusive = $_[2]->{schema}{exclusiveMinimum} // '';
+  return is_num($exclusive)
+    ? JSON::Validator::Schema::Draft6::_validate_number_min(@_)
+    : JSON::Validator::Schema::Draft4::_validate_number_min(@_);
+}
 
 sub _validate_type_array {
   my $self = shift;

--- a/t/issue-273-boolean-exclusive-bounds.t
+++ b/t/issue-273-boolean-exclusive-bounds.t
@@ -1,0 +1,70 @@
+use Mojo::Base -strict;
+use JSON::Validator;
+use Mojo::JSON qw(false true);
+use Test::More;
+
+# https://github.com/jhthorsen/json-validator/issues/273
+# OpenAPI v3.0 uses draft4 semantics, where exclusiveMinimum/exclusiveMaximum
+# are booleans modifying minimum/maximum, while OpenAPI v3.1 uses numbers.
+
+my $v30 = JSON::Validator->new->schema(spec(
+  '3.0.1',
+  {name => 'ex_min', in => 'query', schema => {type => 'number', minimum => 5,  exclusiveMinimum => true}},
+  {name => 'in_min', in => 'query', schema => {type => 'number', minimum => 5,  exclusiveMinimum => false}},
+  {name => 'ex_max', in => 'query', schema => {type => 'number', maximum => 10, exclusiveMaximum => true}},
+))->schema;
+
+is "@{$v30->errors}", '', 'v3.0 spec is valid';
+
+my $ex_min = $v30->get('/paths/~1x/get/parameters/0/schema');
+is validate($v30, $ex_min, 5.1), '',                      'boolean exclusiveMinimum=true accepts 5.1';
+is validate($v30, $ex_min, 0.5), '/: 0.5 <= minimum(5)',  'boolean exclusiveMinimum=true rejects 0.5';
+is validate($v30, $ex_min, 5),   '/: 5 <= minimum(5)',    'boolean exclusiveMinimum=true rejects boundary 5';
+
+my $in_min = $v30->get('/paths/~1x/get/parameters/1/schema');
+is validate($v30, $in_min, 5),   '',                      'boolean exclusiveMinimum=false accepts boundary 5';
+is validate($v30, $in_min, 4.9), '/: 4.9 < minimum(5)',   'boolean exclusiveMinimum=false rejects 4.9';
+
+my $ex_max = $v30->get('/paths/~1x/get/parameters/2/schema');
+is validate($v30, $ex_max, 9.9), '',                      'boolean exclusiveMaximum=true accepts 9.9';
+is validate($v30, $ex_max, 2),   '',                      'boolean exclusiveMaximum=true accepts 2';
+is validate($v30, $ex_max, 10),  '/: 10 >= maximum(10)',  'boolean exclusiveMaximum=true rejects boundary 10';
+
+# Validation must not autovivify exclusiveMinimum/exclusiveMaximum in the schema
+my $plain = {type => 'number', minimum => 1};
+is validate($v30, $plain, 2), '', 'plain minimum accepts 2';
+ok !exists $plain->{exclusiveMinimum} && !exists $plain->{exclusiveMaximum}, 'schema not modified';
+
+# OpenAPI v3.1 numeric (draft 2019-09 style) values must keep working
+my $v31 = JSON::Validator->new->schema(spec(
+  '3.1.0',
+  {name => 'ex_min', in => 'query', schema => {type => 'number', exclusiveMinimum => 5}},
+  {name => 'ex_max', in => 'query', schema => {type => 'number', exclusiveMaximum => 10}},
+))->schema;
+
+is "@{$v31->errors}", '', 'v3.1 spec is valid';
+
+my $num_min = $v31->get('/paths/~1x/get/parameters/0/schema');
+is validate($v31, $num_min, 5.1), '',                     'numeric exclusiveMinimum accepts 5.1';
+is validate($v31, $num_min, 5),   '/: 5 <= minimum(5)',   'numeric exclusiveMinimum rejects boundary 5';
+
+my $num_max = $v31->get('/paths/~1x/get/parameters/1/schema');
+is validate($v31, $num_max, 9.9), '',                     'numeric exclusiveMaximum accepts 9.9';
+is validate($v31, $num_max, 10),  '/: 10 >= maximum(10)', 'numeric exclusiveMaximum rejects boundary 10';
+
+done_testing;
+
+sub spec {
+  my ($version, @parameters) = @_;
+  return {
+    openapi => $version,
+    info    => {title => 'issue-273', version => '1'},
+    paths   =>
+      {'/x' => {get => {parameters => \@parameters, responses => {200 => {description => 'ok'}}}}},
+  };
+}
+
+sub validate {
+  my ($schema, $sub_schema, $value) = @_;
+  return join ', ', $schema->validate($value, $sub_schema);
+}


### PR DESCRIPTION
### Summary

`JSON::Validator::Schema::OpenAPIv3` now selects the semantics for `exclusiveMinimum`/`exclusiveMaximum` based on the type of
the value:

- boolean or absent → draft4 semantics: `exclusiveMinimum: true` makes `minimum` an exclusive bound, `false`/absent keeps it
  inclusive (delegates to `Draft4`)
- numeric → the value itself is the exclusive bound, as in OpenAPI v3.1 / draft 2019-09 (delegates to `Draft6`, unchanged
  behavior)

A new test, `t/issue-273-boolean-exclusive-bounds.t`, covers boolean bounds and their boundary values in an OpenAPI 3.0
document, numeric bounds in an OpenAPI 3.1 document, and that validation does not modify the input schema.

### Motivation

OpenAPI 3.0 uses draft4 JSON Schema semantics, where `exclusiveMinimum`/`exclusiveMaximum` are booleans modifying
`minimum`/`maximum`. Only OpenAPI 3.1 changed them to standalone numbers. Since `OpenAPIv3` inherited its number validation
from `Draft201909` (numeric-only semantics), a boolean `true` in a 3.0 document was numified to `1` and used as the bound,
so valid data was rejected and the actual boundary was not enforced:

```perl
# OpenAPI 3.0 schema: {type => 'number', minimum => 0, exclusiveMinimum => true}
# means: valid iff n > 0
$schema->validate(0.5, $sub);  # before: "/: 0.5 <= minimum(1)" — rejected

$schema->validate(5, {type => 'number', minimum => 5, exclusiveMinimum => true});
                               # before: passes, but 5 is not > 5
```

### References

- Fixes #273
- OpenAPI 3.0 schema object docs (exclusiveMinimum/exclusiveMaximum follow JSON Schema Validation Wright Draft 00):
  https://spec.openapis.org/oas/v3.0.3#properties
- OpenAPI 3.1 changed to JSON Schema draft 2020-12, where these keywords are numbers:
  https://spec.openapis.org/oas/v3.1.0#properties
