### PR TITLE
Add license information for bundled schema files #278

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,10 @@ Copyright (C) 2014-2021, Jan Henning Thorsen
 This program is free software, you can redistribute it and/or modify it under
 the terms of the Artistic License version 2.0.
 
+This distribution bundles cached copies of JSON Schema and OpenAPI schema
+files published by third parties. See `lib/JSON/Validator/cache/LICENSE`
+for their copyright and license information.
+
 # AUTHORS
 
 ## Project Founder

--- a/lib/JSON/Validator.pm
+++ b/lib/JSON/Validator.pm
@@ -452,6 +452,10 @@ Copyright (C) 2014-2021, Jan Henning Thorsen
 This program is free software, you can redistribute it and/or modify it under
 the terms of the Artistic License version 2.0.
 
+This distribution bundles cached copies of JSON Schema and OpenAPI schema
+files published by third parties. See C<lib/JSON/Validator/cache/LICENSE>
+for their copyright and license information.
+
 =head1 AUTHORS
 
 =head2 Project Founder

--- a/lib/JSON/Validator/cache/LICENSE
+++ b/lib/JSON/Validator/cache/LICENSE
@@ -1,0 +1,491 @@
+LICENSE INFORMATION FOR BUNDLED SCHEMA FILES
+============================================
+
+The files in this directory are cached copies of schema documents, most of
+them published by third parties, bundled with the JSON-Validator
+distribution so that these specifications can be resolved without network
+access. Each file is named after the MD5 checksum of the URL it was
+downloaded from (see JSON::Validator::Store for the lookup logic).
+
+The sections below list the origin, copyright and license of every bundled
+file. The full license texts follow at the end of this file.
+
+JSON Schema meta-schemas
+------------------------
+Source:    https://github.com/json-schema-org/json-schema-spec
+Copyright: (c) JSON Schema Specification Authors
+License:   BSD-3-Clause or AFL-3.0 (see "JSON Schema license" below)
+
+  49c95b866e40f788892a7fb3c816b0e8  http://json-schema.org/draft-04/schema
+  3d35aac549d951f4cf9182ff47bff0b4  http://json-schema.org/draft-06/schema
+  4a31fe43be9e23ca9eb8d9e9faba8892  http://json-schema.org/draft-07/schema
+  c6f188eb288cf986f23db49297b25e83  https://json-schema.org/draft/2019-09/schema
+  546acf85ddc442761c18517490215b90  https://json-schema.org/draft/2019-09/meta/applicator
+  089e74a6d17f64af17a9efd6d0fa0de6  https://json-schema.org/draft/2019-09/meta/content
+  3be3f46eb248daf48925640f8ef057e8  https://json-schema.org/draft/2019-09/meta/core
+  d18065ce8fb1f748e766b2737bae5200  https://json-schema.org/draft/2019-09/meta/format
+  7fe97ed1a4c3fac607dd276b2b298275  https://json-schema.org/draft/2019-09/meta/meta-data
+  d8cf7ae7a0fd14accadf5d18bc84d14f  https://json-schema.org/draft/2019-09/meta/validation
+
+OpenAPI / Swagger schemas
+-------------------------
+Source:    https://github.com/OAI/OpenAPI-Specification
+Copyright: (c) OpenAPI Initiative TSC and OpenAPI Specification contributors
+License:   Apache-2.0 (full text below)
+
+  36d1bd12eeed51e86c8695bd8876a9df  http://swagger.io/v2/schema.json
+  10a5eeb37fcd5d829449028f7ceb0774  http://swagger.io/v3/schema.yaml
+  4550dd8afbfee9e71377b45f5fea42ce  https://spec.openapis.org/oas/3.0/schema/2021-09-28
+  33912dbbde6e1d936140f1c82b283d01  https://spec.openapis.org/oas/3.1/schema/2021-05-20
+
+JSON Patch schema
+-----------------
+Source:    https://github.com/SchemaStore/schemastore (src/schemas/json/json-patch.json)
+Copyright: 2014 Mads Kristensen
+License:   Apache-2.0 (full text below)
+
+  ea34d47d4e060a1c3b12d2287aff89a7  http://json.schemastore.org/json-patch
+
+Swagger "Petstore" example
+--------------------------
+Copyright: wordnik api team (http://developer.wordnik.com)
+License:   CC-BY-4.0 (https://creativecommons.org/licenses/by/4.0/)
+
+The license is also declared inside the document itself.
+
+  a0f5b4b4e75ea17fc09e88ec0343d148  (Swagger 2.0 "Petstore" example)
+
+JSON::Validator default error schema
+------------------------------------
+These two files are identical copies of this distribution's own default
+error schema, previously published at http://git.io/vcKD4. They are
+covered by the same license as the JSON-Validator distribution itself:
+the Artistic License version 2.0.
+
+  eaa832720f36cff0abc20c05236a9cd9  http://git.io/vcKD4
+  630949337805585c8e52deea27d11419  (same document under a second cache key)
+
+
+JSON Schema license (BSD-3-Clause or AFL-3.0)
+=============================================
+
+Copyright (c) 2022 JSON Schema Specification Authors
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+This Academic Free License (the "License") applies to any original work
+of authorship (the "Original Work") whose owner (the "Licensor") has
+placed the following licensing notice adjacent to the copyright notice
+for the Original Work:
+
+Licensed under the Academic Free License version 3.0
+
+1) Grant of Copyright License. Licensor grants You a worldwide,
+royalty-free, non-exclusive, sublicensable license, for the duration of
+the copyright, to do the following:
+
+a) to reproduce the Original Work in copies, either alone or as part of
+a collective work;
+
+b) to translate, adapt, alter, transform, modify, or arrange the
+Original Work, thereby creating derivative works ("Derivative Works")
+based upon the Original Work;
+
+c) to distribute or communicate copies of the Original Work and
+Derivative Works to the public, under any license of your choice that
+does not contradict the terms and conditions, including Licensor's
+reserved rights and remedies, in this Academic Free License;
+
+d) to perform the Original Work publicly; and
+
+e) to display the Original Work publicly.
+
+2) Grant of Patent License. Licensor grants You a worldwide,
+royalty-free, non-exclusive, sublicensable license, under patent claims
+owned or controlled by the Licensor that are embodied in the Original
+Work as furnished by the Licensor, for the duration of the patents, to
+make, use, sell, offer for sale, have made, and import the Original Work
+and Derivative Works.
+
+3) Grant of Source Code License. The term "Source Code" means the
+preferred form of the Original Work for making modifications to it
+and all available documentation describing how to modify the Original
+Work. Licensor agrees to provide a machine-readable copy of the Source
+Code of the Original Work along with each copy of the Original Work
+that Licensor distributes. Licensor reserves the right to satisfy this
+obligation by placing a machine-readable copy of the Source Code in an
+information repository reasonably calculated to permit inexpensive and
+convenient access by You for as long as Licensor continues to distribute
+the Original Work.
+
+4) Exclusions From License Grant. Neither the names of Licensor, nor
+the names of any contributors to the Original Work, nor any of their
+trademarks or service marks, may be used to endorse or promote products
+derived from this Original Work without express prior permission of the
+Licensor. Except as expressly stated herein, nothing in this License
+grants any license to Licensor's trademarks, copyrights, patents, trade
+secrets or any other intellectual property. No patent license is granted
+to make, use, sell, offer for sale, have made, or import embodiments
+of any patent claims other than the licensed claims defined in Section
+2. No license is granted to the trademarks of Licensor even if such
+marks are included in the Original Work. Nothing in this License shall
+be interpreted to prohibit Licensor from licensing under terms different
+from this License any Original Work that Licensor otherwise would have a
+right to license.
+
+5) External Deployment. The term "External Deployment" means the use,
+distribution, or communication of the Original Work or Derivative
+Works in any way such that the Original Work or Derivative Works may
+be used by anyone other than You, whether those works are distributed
+or communicated to those persons or made available as an application
+intended for use over a network. As an express condition for the grants
+of license hereunder, You must treat any External Deployment by You of
+the Original Work or a Derivative Work as a distribution under section
+1(c).
+
+6) Attribution Rights. You must retain, in the Source Code of any
+Derivative Works that You create, all copyright, patent, or trademark
+notices from the Source Code of the Original Work, as well as any
+notices of licensing and any descriptive text identified therein as an
+"Attribution Notice." You must cause the Source Code for any Derivative
+Works that You create to carry a prominent Attribution Notice reasonably
+calculated to inform recipients that You have modified the Original
+Work.
+
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants
+that the copyright in and to the Original Work and the patent rights
+granted herein by Licensor are owned by the Licensor or are sublicensed
+to You under the terms of this License with the permission of the
+contributor(s) of those copyrights and patent rights. Except as
+expressly stated in the immediately preceding sentence, the Original
+Work is provided under this License on an "AS IS" BASIS and WITHOUT
+WARRANTY, either express or implied, including, without limitation,
+the warranties of non-infringement, merchantability or fitness for a
+particular purpose. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL
+WORK IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential
+part of this License. No license to the Original Work is granted by this
+License except under this disclaimer.
+
+8) Limitation of Liability. Under no circumstances and under no legal
+theory, whether in tort (including negligence), contract, or otherwise,
+shall the Licensor be liable to anyone for any indirect, special,
+incidental, or consequential damages of any character arising as a
+result of this License or the use of the Original Work including,
+without limitation, damages for loss of goodwill, work stoppage,
+computer failure or malfunction, or any and all other commercial damages
+or losses. This limitation of liability shall not apply to the extent
+applicable law prohibits such limitation.
+
+9) Acceptance and Termination. If, at any time, You expressly
+assented to this License, that assent indicates your clear and
+irrevocable acceptance of this License and all of its terms and
+conditions. If You distribute or communicate copies of the Original
+Work or a Derivative Work, You must make a reasonable effort under the
+circumstances to obtain the express assent of recipients to the terms
+of this License. This License conditions your rights to undertake
+the activities listed in Section 1, including your right to create
+Derivative Works based upon the Original Work, and doing so without
+honoring these terms and conditions is prohibited by copyright law and
+international treaty. Nothing in this License is intended to affect
+copyright exceptions and limitations (including "fair use" or "fair
+dealing"). This License shall terminate immediately and You may no
+longer exercise any of the rights granted to You by this License upon
+your failure to honor the conditions in Section 1(c).
+
+10) Termination for Patent Action. This License shall terminate
+automatically and You may no longer exercise any of the rights granted
+to You by this License as of the date You commence an action, including
+a cross-claim or counterclaim, against Licensor or any licensee
+alleging that the Original Work infringes a patent. This termination
+provision shall not apply for an action alleging patent infringement by
+combinations of the Original Work with other software or hardware.
+
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating
+to this License may be brought only in the courts of a jurisdiction
+wherein the Licensor resides or in which Licensor conducts its primary
+business, and under the laws of that jurisdiction excluding its
+conflict-of-law provisions. The application of the United Nations
+Convention on Contracts for the International Sale of Goods is
+expressly excluded. Any use of the Original Work outside the scope
+of this License or after its termination shall be subject to the
+requirements and penalties of copyright or patent law in the appropriate
+jurisdiction. This section shall survive the termination of this
+License.
+
+12) Attorneys' Fees. In any action to enforce the terms of this License
+or seeking damages relating thereto, the prevailing party shall
+be entitled to recover its costs and expenses, including, without
+limitation, reasonable attorneys' fees and costs incurred in connection
+with such action, including any appeal of such action. This section
+shall survive the termination of this License.
+
+13) Miscellaneous. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable.
+
+14) Definition of "You" in This License. "You" throughout this License,
+whether in upper or lower case, means an individual or a legal entity
+exercising rights under, and complying with all of the terms of, this
+License. For legal entities, "You" includes any entity that controls,
+is controlled by, or is under common control with you. For purposes of
+this definition, "control" means (i) the power, direct or indirect, to
+cause the direction or management of such entity, whether by contract
+or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+15) Right to Use. You may use the Original Work in all ways not
+otherwise restricted or conditioned by this License or by law, and
+Licensor promises not to interfere with or be responsible for such uses
+by You.
+
+16) Modification of This License. This License is Copyright ©
+2005 Lawrence Rosen. Permission is granted to copy, distribute, or
+communicate this License without modification. Nothing in this License
+permits You to modify this License as applied to the Original Work or
+to Derivative Works. However, You may modify the text of this License
+and copy, distribute or communicate your modified version (the "Modified
+License") and apply it to other original works of authorship subject
+to the following conditions: (i) You may not indicate in any way that
+your Modified License is the "Academic Free License" or "AFL" and you
+may not use those names in the name of your Modified License; (ii) You
+must replace the notice specified in the first paragraph above with
+the notice "Licensed under <insert your license name here>" or with a
+notice of your own that is not confusingly similar to the notice in
+this License; and (iii) You may not claim that your original works are
+open source software unless your Modified License has been approved by
+Open Source Initiative (OSI) and You comply with its license review and
+certification process.
+
+
+Apache License 2.0
+==================
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
### Summary

Adds `lib/JSON/Validator/cache/LICENSE` documenting every bundled cache file's source URL (verified as the MD5 of the URL),
upstream project, copyright and license, plus the full BSD-3-Clause/AFL-3.0 and Apache-2.0 texts (Apache-2.0 section 4a requires
shipping a copy). Since everything under `lib/` is installed, the license travels with the schemas into the tarball and
installed trees; `JSON::Validator::Store` looks cache files up by exact MD5 name, so the extra file has no runtime effect.

A one-sentence pointer is added to the `COPYRIGHT AND LICENSE` section of the `JSON::Validator` POD, mirrored in `README.md`.

Open question: the Swagger Petstore example (`a0f5b4b4e75ea17fc09e88ec0343d148`, CC-BY-4.0, wordnik) is no longer referenced by
any module or test — would you rather delete it than attribute it?

### Motivation

The schema files bundled in `lib/JSON/Validator/cache/` were redistributed without their licenses, which the JSON Schema and
OpenAPI projects require. The missing license information also caused downstream packaging problems: Debian stripped the cache
files from `libjson-validator-perl`, which broke OpenAPI validation at runtime for applications using the package.

### References

- Fixes #278
- Debian bug [#1091856](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1091856), resolved downstream by researching every
  file's provenance for `debian/copyright` in libjson-validator-perl 5.15+dfsg1-1
